### PR TITLE
Add biosdevname if available

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -91,7 +91,7 @@ systemd: ignore
 terminfo-base: ignore
 update-alternatives: ignore
 
-biosdevname:
+?biosdevname:
 cpio:
 curl:
 device-mapper:


### PR DESCRIPTION
On non intel architectures biosdevname doesn't exist.
