### PR TITLE
install Yast packages via dependencies

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -76,10 +76,6 @@ unzip: ignore
 
 ?efibootmgr:
 ?elilo:
-?yast2-reipl:
-?yast2-s390:
-?yast2-vm:
-autoyast2-installation:
 btrfsprogs:
 bzip2:
 coreutils:
@@ -148,43 +144,6 @@ wget:
 xfsdump:
 xfsprogs:
 xz:
-yast2-add-on:
-yast2-bootloader:
-yast2-core:
-yast2-country-data:
-yast2-country:
-yast2-fcoe-client:
-##
-yast2-hardware-detection:
-yast2-iscsi-client:
-yast2-kdump:
-yast2-ldap-client:
-yast2-multipath:
-yast2-network:
-yast2-nfs-client:
-yast2-ntp-client:
-yast2-packager:
-yast2-pam:
-yast2-perl-bindings:
-yast2-pkg-bindings:
-yast2-proxy:
-yast2-ruby-bindings:
-yast2-security:
-yast2-services-manager:
-##
-yast2-slp:
-yast2-trans-stats:
-##
-yast2-transfer:
-yast2-tune:
-yast2-update:
-yast2-users:
-yast2-x11:
-##
-yast2-xml:
-yast2-ycp-ui-bindings:
-
-# rubygem-nokogiri:
 
 rpm:
   /bin
@@ -252,6 +211,22 @@ if arch eq 'ia64'
   r /usr/lib/ia32el/cpuid
   r /usr/lib/ia32el/auxapp
 endif
+
+
+# The skelcd packages are only used to pull in all Yast packages
+# via dependencies. The control file is actually not needed at all
+# (it's downloaded during installation from the installation source),
+# so we only include the documentation which is later removed.
+# The result is that the inst-sys contains the needed Yast packages
+# without any useless file.
+?skelcd-control-openSUSE:
+  /usr/share/doc/packages/skelcd-control-openSUSE/LICENSE
+
+?skelcd-control-SLES:
+  /usr/share/doc/packages/skelcd-control-SLES/LICENSE
+
+?skelcd-control-SLED:
+  /usr/share/doc/packages/skelcd-control-SLED/LICENSE
 
 yast2:
   /etc

--- a/data/root/theme.file_list
+++ b/data/root/theme.file_list
@@ -1,10 +1,10 @@
 desktop-data-openSUSE:
   /usr/share/desktop-data/qtrc
 
-yast2-qt-branding-<theme>:
+?yast2-qt-branding-<theme>:
   /
 
-yast2-theme-<theme>:
+?yast2-theme-<theme>:
   /
 
 yast2-theme-<yast_theme>:


### PR DESCRIPTION
- there can be different packages in SLES and openSUSE inst-sys
- make some branding packages optional (SLE branding has a different
  package set than openSUSE)

This change also needs changes in the `spec` file, see [diff in Devel:YaST:Head](https://build.suse.de/package/rdiff/Devel:YaST:Head/installation-images?opackage=installation-images&oproject=SUSE%3ASLE-12%3AGA&rev=9) IBS. (BTW why is the spec file not in Git? I could include the change here as well.)

This also fixes P1 [bnc#861074](https://bugzilla.novell.com/show_bug.cgi?id=861074) - please merge and submit to SLE12 **ASAP** (for Alpha3), thank you a lot!
