### PR TITLE
root.file_list: ignore zypper, add optional skelcd-control-SLES-for-VMware

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -74,6 +74,9 @@ unzip: ignore
 ?dracut: ignore
 ?mkinitrd: ignore
 yast2-schema: ignore
+# handle yast2-registration -> suse-connect -> zypper dependency,
+# yast does not need zypper, just suse-connect, so ignore it
+?zypper: ignore
 
 if arch eq 'aarch64'
 qemu-linux-aarch64:
@@ -165,6 +168,7 @@ endif
 # pull in yast2 installation related packages via package deps
 ?skelcd-control-openSUSE:
 ?skelcd-control-SLES:
+?skelcd-control-SLES-for-VMware:
 ?skelcd-control-SLED:
 
 rpm:


### PR DESCRIPTION
- `yast2-registration` has been updated to use `suse-connect` as the backend, however it uses `libzypp` directly, it does not need `zypper` which is used by default when `suse-connect` is used out of Yast
- there is also `skelcd-control-SLES-for-VMware` package so use it if it is present
  (so far it's the same as `skelcd-control-SLES` so it won't change anything, but it is preparation for future when SLES-for-VMware differs from standard SLES)
