### PR TITLE
pata_macio added to modules.conf

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -459,6 +459,7 @@ pata_mpc52xx,mpc52xx PATA,,,,1
 pata_pdc2027x,"Promise PDC20268 to PDC20277",,,,1
 pata_sil680,SI680 PATA QS20,,,,1
 pata_sl82c105,"W82C105 PATA IDE",,,,1
+pata_macio,"PowerMac PATA IDE",,,,1
 ahci,"AHCI SATA driver",,,,1
 sata_sil,"Silicon Image SATA",,,,1
 sata_sil24,"Silicon Image 3124/3132 SATA",,,,1


### PR DESCRIPTION
Probably allows installing opensuse on powermacs
