### PR TITLE
Don't boot installation by default.

### DIFF
--- a/data/boot/grub-powerpc.cfg
+++ b/data/boot/grub-powerpc.cfg
@@ -4,6 +4,8 @@ gfxmode=auto
 locale_dir=$prefix/locale
 lang=en_US
 
+set default='local'
+
 insmod gettext
 
 color_normal=light-gray/black
@@ -32,6 +34,10 @@ menuentry 'Check Installation Media' $arch --class opensuse --class gnu-linux --
   linux /boot/ARCH/linux mediacheck=1
   echo 'Loading initial ramdisk ...'
   initrd /boot/ARCH/initrd
+}
+
+menuentry 'local' {
+  exit
 }
 
 submenu 'Other options...' {


### PR DESCRIPTION
Till now we have Installation started after timeout by default. Lets
default to disk boot.

Signed-off-by: Dinar Valeev dvaleev@suse.com
