### PR TITLE
ca-certifices update.d snippets naming adjust

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -105,8 +105,8 @@ endif
 
 ca-certificates:
   /usr/sbin/update-ca-certificates
-  /usr/lib/ca-certificates/update.d/openssl.run
-  /usr/lib/ca-certificates/update.d/etc_ssl.run
+  /usr/lib/ca-certificates/update.d/*openssl.run
+  /usr/lib/ca-certificates/update.d/*etc_ssl.run
   /var/lib/ca-certificates/openssl
 
 aaa_base:


### PR DESCRIPTION
ca-certifices update.d snippets were renamed to clarify order of calling them. Adjust here (bnc#883386)
