### PR TITLE
Added SuSEfirewall2 sysconfig configuration

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -263,6 +263,12 @@ yast2-installation:
   # hack to make 'repair' option work
   # p repair.diff
 
+# bnc#887406 SuSEfirewall2 configuration needed for AutoYast export
+# both in installation proposal and at the end of installation
+SuSEfirewall2:
+  d /etc/sysconfig/SuSEfirewall2.d/services/
+  /etc/sysconfig/SuSEfirewall2
+
 netcfg:
   /etc/{services,protocols}
 


### PR DESCRIPTION
- Firewall needs to read and modify configuration according to user's decision, but the default configuration has to be present in inst-sys
- bnc#887406
- added /etc/sysconfig/SuSEfirewall2
- SuSEfirewall2 services (SSHD, VNC) are already there
