### PR TITLE
move libgcrypt20-hmac to initrd, as gpg and libgcrypt20 live there

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -283,6 +283,8 @@ gpg2:
   /usr/bin/gpg{,2}
   d root/.gnupg
 
+?libgcrypt20-hmac:
+
 if exists(openSUSE-build-key)
   openSUSE-build-key:
     /usr/lib/rpm/gnupg/keys

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -94,7 +94,6 @@ coreutils:
 cpio:
 cryptsetup:
 ?libcryptsetup4-hmac:
-?libgcrypt20-hmac:
 device-mapper:
 dmraid:
 dosfstools:


### PR DESCRIPTION
otherwise fips=1 fails in /linuxrc already
