### PR TITLE
Removed "Firmware Test" from menu and firmwarekit package (bnc#894094)

### DIFF
--- a/data/boot/message
+++ b/data/boot/message
@@ -13,7 +13,6 @@ Available boot options:
   linux     - Installation
   rescue    - Rescue System
   mediachk  - Check Installation Media
-  firmware  - Firmware Test
   memtest   - Memory Test
 
 Have a lot of fun...

--- a/data/boot/syslinux.cfg
+++ b/data/boot/syslinux.cfg
@@ -24,11 +24,6 @@ label mediachk
   kernel linux
   append initrd=initrd splash=silent mediacheck=1 showopts
 
-# bios test
-label firmware
-  kernel linux
-  append initrd=biostest,initrd splash=silent install=exec:/bin/run_biostest showopts
-
 # memory test
 label memtest
   kernel memtest

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -53,7 +53,6 @@ binutils: ignore
 ?acpica:
 ?efibootmgr:
 ?elilo:
-?firmwarekit:
 ?grub2-i386-pc:
 ?grub2-x86_64-efi:
 ?grub2-powerpc-ieee1275:


### PR DESCRIPTION
- According to bnc#894094, the `Firmware Test` is broken and no longer maintained
- PM decided to drop it from installation media
