### PR TITLE
optionally include custom gpg keys (bnc#895018)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -292,6 +292,10 @@ elsif exists(suse-build-key)
   suse-build-key:
     /usr/lib/rpm/gnupg/keys
 endif
+if exists(custom-build-key)
+  custom-build-key:
+    /usr/lib/rpm/gnupg/keys
+endif
 
 ntfs-3g:
   /


### PR DESCRIPTION
if a package 'custom-build-key' exists, it's keys are merged in
addition to the openSUSE resp SLE keys.
