### PR TITLE
Package qemu-linux-user when available (WIP, not yet tested)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -77,6 +77,7 @@ perl:
 procinfo:
 procps:
 psmisc:
+?qemu-linux-user:
 rpm:
 sed:
 shadow:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -78,6 +78,7 @@ logrotate: ignore
 openssl: ignore
 permissions: ignore
 pinentry: ignore
+?qemu-linux-user:
 suspend: ignore
 update-alternatives: ignore
 ?dracut: ignore

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -142,6 +142,7 @@ polkit:
 procinfo:
 procps:
 psmisc:
+?qemu-linux-user:
 reiserfs:
 rsh:
 sdparm:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -140,6 +140,7 @@ polkit:
 procinfo:
 procps:
 psmisc:
+?qemu-linux-user:
 reiserfs:
 screen:
 sed:


### PR DESCRIPTION
For building installation-images in qemu emulation we need
to embed the qemu-linux-user (needed for aarch64)