### PR TITLE
aarch64: move kernel and initrd to boot/aarch64/loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ BOOT_PARTS    := initrd
 endif
 
 ifneq ($(filter aarch64, $(ARCH)),)
-ALL_TARGETS   := initrd-themes initrd initrd+modules+gefrickel boot-grub2-efi $(COMMON_TARGETS)
+ALL_TARGETS   := initrd-themes initrd initrd+modules+gefrickel boot boot-grub2-efi $(COMMON_TARGETS)
 INSTSYS_PARTS := $(COMMON_INSTSYS_PARTS)
-BOOT_PARTS    := initrd efi
+BOOT_PARTS    := boot/* initrd efi
 endif
 
 ifneq ($(filter ppc ppc64 ppc64le, $(ARCH)),)

--- a/data/boot/boot.file_list
+++ b/data/boot/boot.file_list
@@ -1,14 +1,18 @@
 d loader
-x syslinux.cfg /loader/isolinux.cfg
+if arch eq 'i386' || arch eq 'x86_64'
+  x syslinux.cfg /loader/isolinux.cfg
+endif
 
 <kernel_rpm>:
   a /boot/<kernel_img> /loader/linux
 
-memtest86+:
-  m /boot/memtest.bin /loader/memtest
+if arch eq 'i386' || arch eq 'x86_64'
+  memtest86+:
+    m /boot/memtest.bin /loader/memtest
 
-syslinux:
-  m /usr/share/syslinux/isolinux.bin /loader
-  m /usr/share/syslinux/gfxboot.c32 /loader
-  e isolinux-config --base=/boot/<arch>/loader loader/isolinux.bin
+  syslinux:
+    m /usr/share/syslinux/isolinux.bin /loader
+    m /usr/share/syslinux/gfxboot.c32 /loader
+    e isolinux-config --base=/boot/<arch>/loader loader/isolinux.bin
+endif
 

--- a/install.aarch64
+++ b/install.aarch64
@@ -5,7 +5,7 @@
 set -e
 
 # create directory layout
-mkdir -p $DESTDIR/CD1/boot/$ARCH
+mkdir -p $DESTDIR/CD1/boot/$ARCH/loader
 for theme in $THEMES ; do
   mkdir -p $DESTDIR/branding/$theme/CD1/boot/$ARCH
 done
@@ -21,11 +21,17 @@ for theme in $THEMES ; do
     [ -e images/$theme/$i ] && cp -r images/$theme/$i $DESTDIR/branding/$theme/CD1/boot/$ARCH
   done
 
-  install -m 644 /boot/Image-* $DESTDIR/branding/$theme/CD1/boot/$ARCH/linux
-
   if [ -d images/$theme/EFI ] ; then
     mkdir -p $DESTDIR/branding/$theme/CD1/EFI/BOOT
     cp -r images/$theme/EFI/EFI/BOOT/* $DESTDIR/branding/$theme/CD1/EFI/BOOT
+  fi
+
+  # might be missing if theme does not really exist
+  mkdir -p $DESTDIR/branding/$theme/CD1/boot/$ARCH/loader
+
+  # initrd goes to 'loader' dir
+  if [ -e $DESTDIR/branding/$theme/CD1/boot/$ARCH/initrd ] ; then
+    mv $DESTDIR/branding/$theme/CD1/boot/$ARCH/initrd $DESTDIR/branding/$theme/CD1/boot/$ARCH/loader/initrd
   fi
 done
 


### PR DESCRIPTION
This is needed to correctly work together with the 13.2 instsource KIWI plugin
