### PR TITLE
Rescue: bind-libs is in fact just a collection of libraries, that are au...

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -77,7 +77,6 @@ aaa_base-extras:
 attr:
 bash:
 bc:
-bind-libs:
 bind-utils:
 btrfsprogs:
 bzip2:


### PR DESCRIPTION
...tomatically required by dependencies.

With bind 9.10.1-P1, the shared library packaging policy is being applied to bind, resulting in the collection package bind-libs no longer to exist.

As with all other Shared Libraries, those are not generally listed here, as they tend to change very often (ABI bumps); so we do the same and rely on RPM dependencies to bring us bind-related libs.
