### PR TITLE
Add new kernel module ipvlan for kernel 3.19.0

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -289,6 +289,7 @@ kernel/drivers/net/tokenring/.*
 kernel/drivers/net/can/.*
 kernel/drivers/net/phy/.*
 kernel/drivers/net/ieee802154/.*
+kernel/drivers/net/ipvlan/.*
 kernel/drivers/misc/sgi-xp/.*
 kernel/net/ieee802154/.*
 kernel/net/mac802154/.*


### PR DESCRIPTION

This should fix the build issue of installation-images currently seen at
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:D/installation-images-openSUSE/standard/x86_64 due to kernel 3.19.0