### PR TITLE
Fix samba libs name for samba 4.2.0

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -86,8 +86,8 @@ perl: ignore
 filesystem: ignore
 
 samba-libs: nodeps
-  /usr/lib*/samba/libreplace.so
-  /usr/lib*/samba/libwinbind-client.so
+  /usr/lib*/samba/libreplace*.so
+  /usr/lib*/samba/libwinbind-client*.so
 
 ?biosdevname:
 cpio:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -184,8 +184,8 @@ endif
 # we have full samba in rescue-server
 if filelist ne 'rescue-server'
   samba-libs: nodeps
-    /usr/lib*/samba/libreplace.so
-    /usr/lib*/samba/libwinbind-client.so
+    /usr/lib*/samba/libreplace*.so
+    /usr/lib*/samba/libwinbind-client*.so
 endif
 
 rpm:


### PR DESCRIPTION
Since samba 4.2.0, the samba's libraries renamed with adds -samba4 at the end.