### PR TITLE
Fix dangling symlinks for ca-certificates (with p11-kit 0.23.x)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -108,6 +108,8 @@ ca-certificates:
   /usr/lib/ca-certificates/update.d/*openssl.run
   /usr/lib/ca-certificates/update.d/*etc_ssl.run
   /var/lib/ca-certificates/openssl
+  /etc/ssl/certs
+  /var/lib/ca-certificates/pem
 
 aaa_base:
   E prein
@@ -144,7 +146,6 @@ x create_locale /create_locale
 E /create_locale
 
 # show certificates
-s /var/lib/ca-certificates/pem etc/ssl/certs
 E update-ca-certificates -f
 E ls -lR /var/lib/ca-certificates
 E ls -lR /etc/ssl


### PR DESCRIPTION
It's supposed to fix
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:D/installation-images-openSUSE/standard/i586

and is hopefully the right way to do so.