### PR TITLE
Removed creating links to /usr/lib/YaST2/startup/YaST2.First-Stage

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -254,9 +254,10 @@ yast2:
   /usr
   /var
   r /usr/lib/YaST2/servers_non_y2/ag_cron
-  s /usr/lib/YaST2/startup/YaST2.First-Stage /sbin/yast
-  s /usr/lib/YaST2/startup/YaST2.First-Stage /sbin/yast.ssh
-  r /usr/sbin/yast{,2}
+  # Installer informs user to run yast.ssh in case of SSH-based installation
+  # In other cases, /sbin/yast handles that we are in inst-sys and starts
+  # installer automatically, FATE#317637
+  s /usr/sbin/yast2 /sbin/yast.ssh
 
 ruby:
   /


### PR DESCRIPTION
- FATE#317637
- /sbin/yast (/usr/bin/yast) calls this script itself
- also removed removing /usr/bin/yast
- This is for simpler dud=yast2.rpm - no special changes needed anymore (except yast.ssh)

See also https://github.com/yast/yast-yast2/pull/375