### PR TITLE
Fixed installer name (FATE#317637)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -234,7 +234,7 @@ EOF
 elif [ "$yast" = yast ] ; then
   # now, run yast
   echo "starting yast..."
-  /sbin/yast "$@" ; ec=$?
+  /usr/sbin/yast2 "$@" ; ec=$?
 elif [ "$yast" ] ; then
   # now, run yast
   echo "starting $yast..."


### PR DESCRIPTION
- There is no real /sbin/yast anymore
- It's been /usr/sbin/yast[2] for long time already