### PR TITLE
don't strip anything (bsc #938738)

### DIFF
--- a/bin/mk_image
+++ b/bin/mk_image
@@ -18,7 +18,7 @@ die "usage: $Script\n" if @ARGV;
 
 # env vars:
 #
-# image, src, tmpdir, disjunct, mode, debug, fs, filelist, nolibs, nostrip
+# image, src, tmpdir, disjunct, mode, debug, fs, filelist, nolibs, dostrip
 #
 #
 
@@ -91,7 +91,7 @@ if(!$mode{keep} || $mode{add}) {
   print "fix permissions of directories...\n";
   SUSystem "fix_perms $tmpdir";
 
-  if(!$ENV{nostrip}) {
+  if($ENV{dostrip}) {
     print "strip everything...\n";
     SUSystem "strip_dir $tmpdir";
   }

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -355,6 +355,11 @@ R s/ Server//g etc/issue
 r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
 r dev/mapper dev/stderr dev/initctl
 
+# remove grub2 *.module files, they're not needed
+r usr/lib/grub2/*/*.module
+# ... and strip *.mod files
+S usr/lib/grub2/*/*.mod
+
 # we better have one...
 e touch etc/sysconfig/kernel
 

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -199,7 +199,7 @@ rpm:
   /usr/lib*
   r /usr/lib*/rpm-plugins/sepolicy.so
 
-?grub2:
+?grub2: nodeps
   /usr/bin/grub2-mkpasswd-pbkdf2
 
 gawk:


### PR DESCRIPTION
As it turned out there are more libs involved; so we just don't strip
anything anymore. This doesn't really make a difference but for the grub2
modules (as all our usual libs are already stripped). We just need to add
some special handling for grub2.