### PR TITLE
Drop rsh dependency

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -142,7 +142,6 @@ procinfo:
 procps:
 psmisc:
 reiserfs:
-rsh:
 sdparm:
 sed:
 setserial:


### PR DESCRIPTION
* rsh is outdated and deprecated, upstream is dead
* Removing it here allows removal of rsh from Factory