### PR TITLE
set the default repo location based of the products file (bsc #904755)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -146,6 +146,7 @@ x save_cfg bin/save_cfg
 x restore_cfg bin/restore_cfg
 x unused_mos bin/unused_mos
 x mlist3 bin/mlist3
+x default_repo bin/default_repo
 
 # create locale
 x create_locale /create_locale

--- a/data/base/default_repo
+++ b/data/base/default_repo
@@ -1,0 +1,16 @@
+#! /usr/bin/perl
+
+$repo = "cd:/,hd:/";
+
+$prod = "etc/products.d/baseproduct";
+$prod = "/$prod" if ! -f $prod;
+
+if(open $f, $prod) {
+  while(<$f>) {
+    $repo .= ",$1", last if m#<url\s+name="repository">([^<]+)</url>#;
+  }
+  close $f;
+}
+
+print "$repo\n";
+

--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -72,6 +72,8 @@ e echo "dud:		disk:/?device=*usb*&all=1&quiet=1" >>linuxrc.config
 e echo "autoyast2:	disk:/autoinst.xml?device=*label/OEMDRV&quiet=1" >>linuxrc.config
 e echo "dud:		disk:/?device=*label/OEMDRV&quiet=1" >>linuxrc.config
 
+e echo "defaultrepo:	`default_repo`" >>linuxrc.config
+
 e echo "KexecReboot:    1" >>linuxrc.config
 
 e echo "PTOptions:	AutoUpgrade,productprofile,addon" >>linuxrc.config


### PR DESCRIPTION
With this no special network iso handling is necessary as the network repo
will be automatically considered when nothing is found on any local media (cdrom
or disk).

If the product file does not define any repo, the standard sequence cd,hd
is kept.