### PR TITLE
Add noto-sans and google-roboto-fonts to installation images

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -536,6 +536,10 @@ dejavu-fonts:
 efont-unicode-bitmap-fonts:
   /usr/share/fonts/misc/b16.pcf.gz
 
+?google-roboto-fonts:
+
+?noto-sans:
+
 ?raleway-fonts:
 
 # various asiatic & arabic fonts


### PR DESCRIPTION
As you might have read (hopefully), the default fonts are being switched from dejavu to Roboto & Noto.

Staging:H currently has the font-contig changes done for this - which in turn results (of course) in starnge fonts at this moment in the installer (falls back to some other fonts)

For this to be aligned, I understand we need to get the right fonts into the installation-images package... which this commit is trying to start.

There will also changes on the .spec file needed, but as far as I could see, this is not part of git... so the two fonts need to be buildrequired there.