### PR TITLE
rework product/version handling to use the values from /etc/os-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,38 +94,38 @@ initrd: base
 	[ -s tmp/initrd/bin/bash ]
 
 modules: base
-	image=modules-config src=initrd fs=none bin/mk_image
-	bin/mlist1
-	bin/mlist2
-	image=modules src=initrd fs=none bin/mk_image
+	theme=$(THEMES) image=modules-config src=initrd fs=none bin/mk_image
+	theme=$(THEMES) bin/mlist1
+	theme=$(THEMES) bin/mlist2
+	theme=$(THEMES) image=modules src=initrd fs=none bin/mk_image
 	mkdir -p images/module-config/$${MOD_CFG:-default}
 	ls -I module.config tmp/modules/modules | sed -e 's#.*/##' >images/module-config/$${MOD_CFG:-default}/module.list
 	cp tmp/modules/modules/module.config images/module-config/$${MOD_CFG:-default}
 
 initrd+modules: base
-	image=modules-config src=initrd fs=none bin/mk_image
-	bin/mlist1
-	bin/mlist2
+	theme=$(THEMES) image=modules-config src=initrd fs=none bin/mk_image
+	theme=$(THEMES) bin/mlist1
+	theme=$(THEMES) bin/mlist2
 	rm -rf tmp/initrd/modules tmp/initrd/lib/modules
-	mode=add tmpdir=initrd image=modules src=initrd fs=none bin/mk_image
+	theme=$(THEMES) mode=add tmpdir=initrd image=modules src=initrd fs=none bin/mk_image
 	mkdir -p images/module-config/$${MOD_CFG:-default}
 	ls -I module.config tmp/initrd/modules | sed -e 's#.*/##' >images/module-config/$${MOD_CFG:-default}/module.list
 	cp tmp/initrd/modules/module.config images/module-config/$${MOD_CFG:-default}
-	mode=keep image=$(THEMES)/$${image:-initrd} tmpdir=initrd fs=cpio.xz bin/mk_image
+	theme=$(THEMES) mode=keep image=$(THEMES)/$${image:-initrd} tmpdir=initrd fs=cpio.xz bin/mk_image
 
 initrd+modules+gefrickel: base
-	image=modules-config src=initrd fs=none bin/mk_image
-	bin/mlist1
-	bin/mlist2
+	theme=$(THEMES) image=modules-config src=initrd fs=none bin/mk_image
+	theme=$(THEMES) bin/mlist1
+	theme=$(THEMES) bin/mlist2
 	rm -rf tmp/initrd/modules tmp/initrd/lib/modules tmp/initrd_gefrickel
 	# work on a copy to not modify the origial tree
 	cp -a tmp/initrd tmp/initrd_gefrickel
-	mode=add tmpdir=initrd_gefrickel image=modules src=initrd fs=none bin/mk_image
+	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=modules src=initrd fs=none bin/mk_image
 	mkdir -p images/module-config/$${MOD_CFG:-default}
 	ls -I module.config tmp/initrd_gefrickel/modules | sed -e 's#.*/##' >images/module-config/$${MOD_CFG:-default}/module.list
 	cp tmp/initrd_gefrickel/modules/module.config images/module-config/$${MOD_CFG:-default}
 	./gefrickel tmp/initrd_gefrickel
-	mode=keep image=$(THEMES)/$${image:-initrd} tmpdir=initrd_gefrickel fs=cpio.xz bin/mk_image
+	theme=$(THEMES) mode=keep image=$(THEMES)/$${image:-initrd} tmpdir=initrd_gefrickel fs=cpio.xz bin/mk_image
 
 kernel: base
 	image=vmlinuz-$${MOD_CFG:-default} src=initrd filelist=kernel kernel=kernel-$${MOD_CFG:-default} fs=dir bin/mk_image
@@ -172,13 +172,13 @@ root+rescue: base
 	cat data/root/rpmlist tmp/base/yast2-trans-rpm.list >images/rpmlist
 
 gdb: base
-	libdeps=root,gdb image=gdb src=root fs=squashfs disjunct=root bin/mk_image
+	theme=$(THEMES) libdeps=root,gdb image=gdb src=root fs=squashfs disjunct=root bin/mk_image
 
 bind: base
-	libdeps=root,bind image=bind src=root fs=squashfs disjunct=root bin/mk_image
+	theme=$(THEMES)libdeps=root,bind image=bind src=root fs=squashfs disjunct=root bin/mk_image
 
 snapper: base
-	libdeps=root,snapper image=snapper src=root fs=squashfs disjunct=root bin/mk_image
+	theme=$(THEMES) libdeps=root,snapper image=snapper src=root fs=squashfs disjunct=root bin/mk_image
 
 boot-themes: base
 	for theme in $(THEMES) ; do \

--- a/data/boot/mkbootdisk
+++ b/data/boot/mkbootdisk
@@ -11,7 +11,7 @@
 use strict 'vars';
 use integer;
 
-%::ConfigData = ( full_product_name => "product_X" );
+%::ConfigData = ( product_name => "product_X" );
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -699,14 +699,14 @@ use integer;
   # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   my $boot_msg = "\r
-  I'm $::ConfigData{full_product_name} Boot Disk <disk>. I cannot boot. :-(\r
+  I'm $::ConfigData{product_name} Boot Disk <disk>. I cannot boot. :-(\r
   \r
   Please try Boot Disk 1.\r\n";
 
 
   # Not more than 1024 chars (1 cluster)! --> Or adjust cluster size!
   my $readme =
-  "This is $::ConfigData{full_product_name} Boot Disk <disk>.
+  "This is $::ConfigData{product_name} Boot Disk <disk>.
 
   <x_readme>
   To access Boot Disk data, you have to join the individual disk images first:

--- a/etc/config
+++ b/etc/config
@@ -70,10 +70,6 @@ floppy	=
 base    = openSUSE
 splash  = openSUSE
 yast    = openSUSE
-product	= openSUSE
-version = 13.2
-sle     = 12
-update	= /linux/suse/<arch>-<rel>
 image	= 350
 
 
@@ -81,10 +77,6 @@ image	= 350
 base    = SLE
 splash  = SLE
 yast    = SLE
-product	= SUSE Linux Enterprise 12 SP1
-version = 13.2
-sle     = 12
-update	= /linux/suse/<arch>-<sles>
 image	= 600
 
 
@@ -92,10 +84,6 @@ image	= 600
 base    = SLE
 splash  = SLE
 yast    = SLE
-product	= SUSE Linux Enterprise 12 SP1
-version = 13.2
-sle     = 12
-update	= /linux/suse/<arch>-<sled>
 image	= 600
 
 
@@ -103,10 +91,6 @@ image	= 600
 base    = SLE
 splash  = SLE
 yast    = SLE
-product = ZENworks
-version = 13.2
-sle     = 12
-update  = /linux/suse/<arch>-<sles>
 image   = 600
 
 

--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -1,0 +1,69 @@
+== opensuse ==
+
+NAME=openSUSE
+VERSION="13.2 (Harlequin)"
+VERSION_ID="13.2"
+PRETTY_NAME="openSUSE 13.2 (Harlequin) (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:13.2"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"
+
+== tumbleweed ==
+
+NAME=openSUSE
+VERSION="Tumbleweed"
+VERSION_ID="20160126"
+PRETTY_NAME="openSUSE Tumbleweed (20160126) (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:20160126"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+ID_LIKE="suse"
+
+== leap ==
+
+NAME="openSUSE Leap"
+VERSION="42.1"
+VERSION_ID="42.1"
+PRETTY_NAME="openSUSE Leap 42.1 (x86_64)"
+ID=opensuse
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://opensuse.org/"
+ID_LIKE="suse"
+
+== sles12 ==
+
+NAME="SLES"
+VERSION="12"
+VERSION_ID="12"
+PRETTY_NAME="SUSE Linux Enterprise Server 12"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12"
+
+== sles12 sp1 ==
+
+NAME="SLES"
+VERSION="12-SP1"
+VERSION_ID="12.1"
+PRETTY_NAME="SUSE Linux Enterprise Server 12 SP1"
+ID="sles"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:12:sp1"
+
+== sled12 ==
+
+NAME="SLED"
+VERSION="12"
+VERSION_ID="12"
+PRETTY_NAME="SUSE Linux Enterprise Desktop 12"
+ID="sled"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sled:12"
+

--- a/lib/MakeFATImage2.pm
+++ b/lib/MakeFATImage2.pm
@@ -13,14 +13,14 @@ use integer;
 my $boot_file = "${BasePath}src/mboot/boot";
 
 my $boot_msg = "\r
-I'm $ConfigData{full_product_name} Boot Disk <disk>. I cannot boot. :-(\r
+I'm $ConfigData{product_name} Boot Disk <disk>. I cannot boot. :-(\r
 \r
 Please try Boot Disk 1.\r\n";
 
 
 # Not more than 1024 chars (1 cluster)! --> Or adjust cluster size!
 my $readme =
-"This is $ConfigData{full_product_name} Boot Disk <disk>.
+"This is $ConfigData{product_name} Boot Disk <disk>.
 
 <x_readme>
 To access Boot Disk data, you have to join the individual disk images first:


### PR DESCRIPTION
This removes the related static entries from etc/config and ensures
version and product info is always up-to-date.

Also, this implements the new driver update directory naming for
Tumbleweed ('x86_64-tw') and Leap ('x86_64-leap42.1').