### PR TITLE
adjust product/version handling

### DIFF
--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -67,3 +67,13 @@ ID="sled"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:sled:12"
 
+== sles12 for sap ==
+
+NAME="SLES_SAP"
+VERSION="12-SP1"
+VERSION_ID="12.1.0.1"
+PRETTY_NAME="SUSE Linux Enterprise for SAP Applications 12 SP1"
+ID="sles_sap"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles_sap:12:sp1"
+

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -870,8 +870,13 @@ sub get_version_info
 
   my $dist = "\L$config{NAME}";
   $dist =~ s/^opensuse\s*//;
+  # special enterprise products may have extra text beside SLES or SLED
+  $dist = $1 if $dist =~ /(sles|sled)/;
+  # don't accept other names than these
+  $dist = "" if $dist !~ /^(leap|sles|sled)$/;
+
   $dist .= $config{VERSION} eq 'Tumbleweed' ? 'tw' : $config{VERSION_ID};
-  $dist =~ s/\..*$// if $config{NAME} =~ /^(SLES|SLED)$/;;
+  $dist =~ s/\..*$// if $dist =~ /^(sles|sled)/;
 
   # print "dist=\"$dist\"\n";
 


### PR DESCRIPTION
The existing implementation would produce unexpected driver update layouts
for SLES derived products. So we adjust the approach a bit and make sure
only the documented driver update dist tags survive (sles, sled, leap, tw).
 On branch test_20