### PR TITLE
Update initrd.file_list according to the sysvinit change

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -260,9 +260,11 @@ ntfs-3g:
 ?kexec-tools: nodeps
   /usr/sbin/kexec
 
-sysvinit-tools: nodeps
+blog:
   /sbin/showconsole
   c 755 0 0 /sbin/showconsole
+
+sysvinit-tools: nodeps
   /sbin/startproc
 
 rpm:


### PR DESCRIPTION
Now showconsole is splits from sysvinit as the separate package called blog.

Per https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:C/installation-images-openSUSE/standard/x86_64 , I hope this is the right fix, please review.

Ref. https://build.opensuse.org/request/show/356283 and https://build.opensuse.org/request/show/360535