### PR TITLE
Also allow desktop-specific mimeapps.list files

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -414,4 +414,5 @@ d usr/lib/microcode
 
 # allowed dangling symlinks
 D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
+D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -705,6 +705,7 @@ x lang_fonts /usr/share/libyui/data/lang_fonts
 D ../../sbin/update-ca-certificates /usr/lib64/p11-kit/p11-kit-extract-trust
 D ../../sbin/update-ca-certificates /usr/lib/p11-kit/p11-kit-extract-trust
 D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
+D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list
 D ../share/cracklib/pw_dict.pwi /usr/lib/cracklib_dict.pwi
 D ../share/cracklib/pw_dict.pwd /usr/lib/cracklib_dict.pwd

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -281,4 +281,5 @@ E TZ= LANG= LC_ALL= date +%Y%m%d >.timestamp
 
 # allowed dangling symlinks
 D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
+D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list


### PR DESCRIPTION
Fixes build fails such as:
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:D/installation-images-openSUSE/standard/i586 (I hope.. untested)