### PR TITLE
Remove uga grub2 module

### DIFF
--- a/data/boot/grub-aarch64.cfg
+++ b/data/boot/grub-aarch64.cfg
@@ -8,7 +8,6 @@ search --no-floppy --file /boot/aarch64/efi --set
 prefix=($root)/boot/aarch64/grub2-efi
 
 insmod efi_gop
-insmod efi_uga
 insmod gzio
 insmod gettext
 


### PR DESCRIPTION
This doesn't seem to be necessary on aarch64 and doesn't exist,
so avoid the error message "Failed to find module".