### PR TITLE
Added modprobe for fuse so that hmcdrv can actually work

### DIFF
--- a/data/initrd/scripts/url/hmc/mount
+++ b/data/initrd/scripts/url/hmc/mount
@@ -6,6 +6,7 @@ set -e
 
 echo "url_dir = '$url_dir'"
 
+modprobe fuse
 modprobe hmcdrv
 
 if [ -d "$url_dir" ] ; then


### PR DESCRIPTION
Attempting the hmcdrvfs command fails unless the fuse kernel module is already loaded.