### PR TITLE
Ruby debugger support (FATE#318421)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -186,6 +186,12 @@ endif
 ?skelcd-control-SLES-for-VMware:
 ?skelcd-control-SLED:
 
+# fix the symlinks for the Ruby debugger if it is present
+?ruby*.*-rubygem-byebug:
+  /
+  # avoid update-alternatives, remove the dangling symlinks and create a new one
+  e cd usr/bin ; find . -type l | grep byebug | xargs rm -rf ; ln -snf byebug.ruby* byebug
+
 rpm:
   /bin
   /etc

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -651,6 +651,9 @@ r /var/adm/autoinstall /var/lib/autoinstall
 e rm -f `find var/log -type f`
 e rm -f `find var/cache -type f`
 
+# remove the Ruby gem cache files
+r /usr/lib*/ruby/gems/*/cache/*.gem
+
 # show remaining files in /var
 e find var -type f
 


### PR DESCRIPTION
- Fix `byebug` symlinks (`update-alternatives` cannot be used)
- Additionally remove the not needed `cache/*.gem` files to save some space

After the space optimization the `root` image is smaller by ~60kB, so even after adding the Ruby debugger we still have a smaller image than before.