### PR TITLE
module.config: add macsec

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -279,6 +279,7 @@ arcnet,"ARCnet","io=0x300"
 bmac,"Apple bmac (PowerMacs with Mach64)"
 fddi,-,-
 mace,"Apple mace (old PowerMacs)"
+macsec
 macvlan
 macvtap
 mdio,-,-


### PR DESCRIPTION
This is a module added in 4.6 and similar to macvlan, macvtap.