### PR TITLE
Add xen-tools-domU on x86 to get its udev rules (bsc#979002)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -95,6 +95,7 @@ tar:
 util-linux-systemd:
 vlan:
 which:
+?xen-tools-domU:
 
 if theme eq 'SLES'
   sles-release:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -165,6 +165,7 @@ vim:
 vlan:
 wget:
 ?wicked:
+?xen-tools-domU:
 xfsdump:
 xfsprogs:
 xz:


### PR DESCRIPTION
For  TW and SLE12.
Signed-off-by: Olaf Hering <olaf@aepfle.de>