### PR TITLE
change how rubygem-byebug is added to inst-sys

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -29,6 +29,12 @@ TEMPLATE ruby.*-rubygem-suse-connect:
   # avoid update-alternatives
   e cd usr/bin ; ln -snf SUSEConnect* SUSEConnect
 
+# fix the symlinks for the Ruby debugger if it is present
+TEMPLATE ruby.*-rubygem-byebug:
+  /
+  # avoid update-alternatives, remove the dangling symlinks and create a new one
+  e cd usr/bin ; find . -type l | grep byebug | xargs rm -rf ; ln -snf byebug.ruby* byebug
+
 # ruby maintainers can't really make up their minds on how to name their packages...
 TEMPLATE ruby.*-rubygem-yard: ignore
   # just a template that does nothing
@@ -185,12 +191,6 @@ endif
 ?skelcd-control-SLES:
 ?skelcd-control-SLES-for-VMware:
 ?skelcd-control-SLED:
-
-# fix the symlinks for the Ruby debugger if it is present
-?ruby*.*-rubygem-byebug:
-  /
-  # avoid update-alternatives, remove the dangling symlinks and create a new one
-  e cd usr/bin ; find . -type l | grep byebug | xargs rm -rf ; ln -snf byebug.ruby* byebug
 
 rpm:
   /bin


### PR DESCRIPTION
It can happen that the project we build against has several versions of ruby
gems. To avoid that the gem is installed more than once, add it as TEMPLATE
to file_list, so that it's dragged in only via package dependencies.