### PR TITLE
set EGL_LOG_LEVEL=0 to stop some libELG warning (bsc #976374, bsc #970883)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -160,6 +160,7 @@ fi
 
 export XCURSOR_THEME=DMZ
 export LIBGL_ALWAYS_INDIRECT=1
+export EGL_LOG_LEVEL=0
 
 grep -qwi start_shell /proc/cmdline && START_SHELL=1
 grep -qi "^StartShell:.*1" /etc/install.inf && START_SHELL=1


### PR DESCRIPTION
According to Egbert's suggestion in https://bugzilla.suse.com/show_bug.cgi?id=970883#c3