### PR TITLE
Drop some unused packages from the root image

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -98,6 +98,14 @@ yast2-schema: ignore
 # already in initrd
 ca-certificates-mozilla: ignore
 filesystem: ignore
+# not needed during installation, added by the
+# "perl-Bootloader < kexec-tools < kdump < yast2-kdump" dependency
+perl-Bootloader: ignore
+# required by .ag_anyxml (yast2) but not needed during installation
+perl-XML-Simple: ignore
+# we need only the "y2tool" and "showy2log" scripts, ignore the dependencies
+yast2-devtools: nodeps
+yast2-buildtools: nodeps
 
 ?efibootmgr:
 ?elilo:
@@ -144,11 +152,8 @@ openslp:
 openslp-server:
 parted:
 pciutils:
-perl-Bootloader:
 perl-XML-Bare:
 perl-XML-NamespaceSupport:
-perl-XML-Parser:
-perl-XML-Simple:
 perl-gettext:
 polkit:
 procinfo:


### PR DESCRIPTION
ignore dependencies:
- yast2-devtools
- yast2-buildtools

removed packages:
- perl-Bootloader
- perl-XML-Parser
- perl-XML-Simple

## Result

As the result these packages were removed from the inst-sys (compared the `.packages.root` files in inst-sys):

- perl-Bootloader
- perl-XML-Parser
- perl-XML-SAX
- perl-XML-SAX-Base
- perl-XML-SAX-Expat
- perl-XML-Simple
- perl-XML-Writer

The size of the `root` image decreased by ~320kB. 
