### PR TITLE
reduce instsys size by removing files already in initrd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ boot: base
 	theme=$(THEMES) image=boot fs=dir bin/mk_image
 
 root: base
-	theme=$(THEMES) libdeps=root image=root bin/mk_image
+	theme=$(THEMES) libdeps=root,initrd image=root bin/mk_image
 
 rescue: base
 	theme=$(THEMES) libdeps=rescue image=rescue bin/mk_image
@@ -162,8 +162,11 @@ rescue-server:
 	theme=$(THEMES) image=rescue-server src=rescue filelist=rescue-server fs=squashfs bin/mk_image
 
 root+rescue: base
+	# the next two lines just clean up old files
 	image=root+rescue fs=none bin/mk_image
-	bin/common_tree --dst tmp/root+rescue tmp/rescue tmp/root
+	image=root+initrd src=root+rescue fs=none filelist=root+rescue bin/mk_image
+	bin/common_tree --dst tmp/root+initrd tmp/initrd tmp/root
+	bin/common_tree --dst tmp/root+rescue tmp/rescue tmp/root+initrd/2
 	mode=keep tmpdir=root+rescue/c image=common fs=squashfs bin/mk_image
 	mode=keep tmpdir=root+rescue/1 image=rescue fs=squashfs bin/mk_image
 	mode=keep tmpdir=root+rescue/2 image=root fs=squashfs bin/mk_image

--- a/bin/common_tree
+++ b/bin/common_tree
@@ -37,7 +37,7 @@ for $dir (@dir_list) {
   for (`find '$dir'`) {
     chomp;
     ($mode, $size) = (lstat)[2,7];
-    if(s/^$dir\///) {
+    if(s/^\Q$dir\E\///) {
       $size = 0 if -d _;
       $i = '*';
       $i = 'b' if -b _;

--- a/bin/common_tree
+++ b/bin/common_tree
@@ -1,5 +1,13 @@
 #! /usr/bin/perl
 
+# common_tree --dst xxx foo1 foo2
+#
+# will create 3 directories xxx/1, xxx/2, and xxx/c which contain
+#
+#   xxx/1: all in foo1 but not in foo2,
+#   xxx/2: all in foo2 but not in foo1,
+#   xxx/c: everyting both in foo1 and foo2
+
 use Getopt::Long;
 use Digest::MD5;
 

--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -57,9 +57,8 @@ else
   e echo "MemYaST:	123456" >>linuxrc.config
 endif
 
-if instsys_complain
-  e echo "InstsysComplain:	<instsys_complain>" >>linuxrc.config
-endif
+# enforce that the inst-sys matches the initrd
+e echo "InstsysComplain:	2" >>linuxrc.config
 
 if instsys_build_id
   e echo "InitrdID:	<instsys_build_id>" >>linuxrc.config


### PR DESCRIPTION
Here's how it works:

`common_tree --dst xxx foo bar`

will create 3 directories `xxx/1`, `xxx/2`, and `xxx/c` which contain `all in foo but not in bar`, `all in bar but not in foo`, and `everyting both in foo and bar`, respectively.

So, in this patch, `tmp/root+initrd/2` contains everything in the root image that's not already in the initrd.