### PR TITLE
Adjust the OOM killers score for haveged (bsc#974601)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -6,6 +6,14 @@ chmod 700 /root/.gnupg
 
 if [ -x /usr/sbin/haveged ] ; then
   /usr/sbin/haveged -w 1024 -v 0
+
+  # Adjust the OOM killer score so kernel prefers killing the haveged
+  # daemon instead of the YaST installer (or it's child).
+  # The entropy will be collected by kernel anyway, just slower without haveged.
+  if [ -f /var/run/haveged.pid ] ; then
+    haveged_pid=`cat /var/run/haveged.pid`
+    echo 1000 > /proc/$haveged_pid/oom_score_adj
+  fi
 fi
 
 if [ -d /usr/lib/rpm/gnupg/keys ] ; then


### PR DESCRIPTION
The OOM killer should prefer killing the haveged daemon first, the installation can be finished without it.
Haveged only generates the entropy for kernel, kernel does that itself but slowly.

According to the log in the bug haveged takes about 4MB memory - not much but maybe be that after killing it the installation can be finished successfully.