### PR TITLE
Include perl-XML-Simple again in inst-sys (bsc#989702)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -101,8 +101,6 @@ filesystem: ignore
 # not needed during installation, added by the
 # "perl-Bootloader < kexec-tools < kdump < yast2-kdump" dependency
 perl-Bootloader: ignore
-# required by .ag_anyxml (yast2) but not needed during installation
-perl-XML-Simple: ignore
 # we need only the "y2tool" and "showy2log" scripts, ignore the dependencies
 yast2-devtools: nodeps
 yast2-buildtools: nodeps


### PR DESCRIPTION
`perl-XML-Simple` requires several other Perl libraries and was a good candidate for the space reduction. Originally I grepped for `.anyxml` usage in YaST and thought it was not needed during installation.

Unfortunately it turned out that the `OneClickInstallStandard.GetRepositoriesFromXML()` call, which is part of the one click installer, uses `.anyxml` and is used in installation to parse the extra repository list in openSUSE.