### PR TITLE
exclude kmod-compat (bsc #989706)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -84,6 +84,7 @@ icewm: ignore
 pkg-config: ignore
 syslog-service: ignore
 kmod: ignore
+kmod-compat: ignore
 gio-branding-upstream: ignore
 hicolor-icon-theme: ignore
 yast2-trans-allpacks: ignore

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -104,6 +104,7 @@ checkmedia:
 ?grub2:
 dbus-1-x11: ignore
 kmod: ignore
+kmod-compat: ignore
 kbd: ignore
 wicked-service: ignore
 ?libsmbios2:


### PR DESCRIPTION
We ignore kmod as it's in the initrd already. Unfortunately kmod-compat
creeps in on ppc64le as dependency of powerpc-utils. So, exclude it
explicity as well.