### PR TITLE
adjust to recent package changes

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -75,6 +75,7 @@ nfsidmap: ignore
 pam-config: ignore
 permissions: ignore
 pinentry: ignore
+python-setuptools: ignore
 sessreg: ignore
 shared-mime-info: ignore
 update-alternatives: ignore
@@ -149,6 +150,7 @@ ntfsprogs:
 open-iscsi:
 openslp:
 openslp-server:
+pam-modules:
 parted:
 pciutils:
 perl-XML-Bare:
@@ -348,9 +350,6 @@ pam:
   /lib*/libpam_misc.so.*
   /lib*
   /sbin
-
-pam-modules:
-  /{lib*,sbin}
 
 cracklib: nodeps
   /usr/sbin/cracklib-check

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -111,9 +111,6 @@ wicked-service: ignore
 gpm:
 
 
-systemd:
-  /usr/lib*/libsystemd*.so.*
-
 krb5:
   /etc
   /usr/lib*/libkrb5.so.*


### PR DESCRIPTION
python-setuptools is really not needed, systemd no longer has libs, and
pam-modules no longer has anything in /sbin