### PR TITLE
update module.config to match 4.7

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -462,6 +462,7 @@ tulip,"DEC Tulip (DC21x4x) PCI"
 ; pegasos
 mv643xx_eth,"Marvell MV643XX"
 mv88e6060,"mv88e6060"
+mv88e6xxx,"mv88e6060"
 mv88e6xxx_drv,"mv88e6060"
 via-rhine,"VIA VT86c100A Rhine-II"
 ; efika
@@ -636,6 +637,7 @@ cuse
 dummy
 eql
 fixed
+gtp
 hyper-v.suse_kmp_dummy
 i2o_bus
 i2o_proc


### PR DESCRIPTION
mv88e6xxx_drv was renamed to mv88e6xxx.

gtp tunelling was added -> put is along pppoe and similar.

Signed-off-by: Jiri Slaby <jirislaby@gmail.com>