### PR TITLE
Make pam-modules optional

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -135,7 +135,7 @@ ntfsprogs:
 open-iscsi:
 ?fcoe-utils:
 openslp:
-pam-modules:
+?pam-modules:
 parted:
 pciutils:
 procinfo:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -150,7 +150,7 @@ ntfsprogs:
 open-iscsi:
 openslp:
 openslp-server:
-pam-modules:
+?pam-modules:
 parted:
 pciutils:
 perl-XML-Bare:


### PR DESCRIPTION
In Factory pam-modules only contains legacy modules that are not
needed by default anymore. Therefore pam-modules won't be available
in buildroot by default anymore.