### PR TITLE
update module.config to match 4.9

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -178,6 +178,7 @@ kernel/drivers/.*/crypto/.*
 kernel/drivers/firmware/.*
 kernel/drivers/i2c/.*
 kernel/drivers/leds/.*
+kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/md/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*


### PR DESCRIPTION
4.9 added ledtrig-usbport, so add it to the list along with other led
drivers.

Signed-off-by: Jiri Slaby jslaby@suse.cz
