### PR TITLE
linuxrc's loghost scripts added FATE#318971

### DIFF
--- a/data/initrd/etc/rsyslog.conf
+++ b/data/initrd/etc/rsyslog.conf
@@ -1,0 +1,92 @@
+# SUSE SPECIFIC rsyslog.conf used for Loghost capability in linuxrc
+###################################################################
+
+# provides --MARK-- message capability (every 1 hour)
+$ModLoad immark.so
+$MarkMessagePeriod      3600
+
+# provides support for local system logging (e.g. via logger command)
+$ModLoad imuxsock.so
+
+# reduce dupplicate log messages (last message repeated n times)
+$RepeatedMsgReduction   on
+
+# kernel logging (may be also provided by /sbin/klogd)
+# see also http://www.rsyslog.com/doc-imklog.html.
+$ModLoad imklog.so
+# set log level 1 (same as in /etc/sysconfig/syslog).
+$klogConsoleLogLevel    1
+
+#
+# Include config files, that the admin provided? :
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Emergency messages to everyone logged on (wall)
+*.emerg					 :omusrmsg:*
+
+#
+# firewall messages into separate file and stop their further processing
+#
+if	($syslogfacility-text == 'kern') and \
+	($msg contains 'IN=' and $msg contains 'OUT=') \
+then {
+	-/var/log/firewall
+	stop
+}
+
+
+#
+# acpid messages into separate file and stop their further processing
+#
+# => all acpid messages for debuging (uncomment if needed):
+#if	($programname == 'acpid' or $syslogtag == '[acpid]:') then \
+#	-/var/log/acpid
+#
+# => up to notice (skip info and debug)
+if	($programname == 'acpid' or $syslogtag == '[acpid]:') and \
+	($syslogseverity <= 5 /* notice */) \
+then {
+	-/var/log/acpid
+	stop
+}
+
+#
+# email-messages
+#
+mail.*					-/var/log/mail
+mail.info				-/var/log/mail.info
+mail.warning				-/var/log/mail.warn
+mail.err				 /var/log/mail.err
+
+
+#
+# news-messages
+#
+news.crit				-/var/log/news/news.crit
+news.err				-/var/log/news/news.err
+news.notice				-/var/log/news/news.notice
+
+#
+# Warnings in one file
+#
+*.=warning;*.=err			-/var/log/warn
+*.crit					 /var/log/warn
+
+
+#
+# the rest in one file
+#
+*.*;mail.none;news.none			-/var/log/messages
+
+
+#
+# Some foreign boot scripts require local7
+#
+local0.*;local1.*			-/var/log/localmessages
+local2.*;local3.*			-/var/log/localmessages
+local4.*;local5.*			-/var/log/localmessages
+local6.*;local7.*			-/var/log/localmessages
+
+#forward kernel msgs to tty4
+kern.*	/dev/tty4

--- a/data/initrd/etc/rsyslog.d/logged_files.conf
+++ b/data/initrd/etc/rsyslog.d/logged_files.conf
@@ -1,0 +1,9 @@
+#enable imfile module
+module(load="imfile" mode="inotify")
+
+#forward y2log
+input(type="imfile"
+      File="/var/log/YaST2/y2log"
+      Tag="yast2_logs"
+      Severity="notice"
+      Facility="local0")

--- a/data/initrd/etc/syslog.conf
+++ b/data/initrd/etc/syslog.conf
@@ -1,1 +1,0 @@
-*.*	/var/log/messages

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -88,6 +88,7 @@ nfsidmap:
 sed:
 ?wicked:
 ?s390-tools-hmcdrvfs:
+rsyslog:
 sysconfig-netconfig:
 sg3_utils:
 systemd-presets-branding-<base_theme>:
@@ -596,8 +597,8 @@ x service_start /bin
 # mini host file
 x etc/host.conf etc
 
-# log to console 4
-x etc/syslog.conf etc
+# we have a custom rsyslog.conf
+x etc/rsyslog.conf etc
 
 # additional scripts for linuxrc
 x scripts /

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -80,8 +80,3 @@ while read ifname xxx ; do
 done < <(/etc/wicked/extensions/ibft -l)
 echo "ibftdevices: $ibft" >/etc/ibft_devices
 
-# log also to console 4 if it exists
-if [ -c /dev/tty4 ] ; then
-  echo "*.*	/dev/tty4" >>/etc/syslog.conf
-fi
-

--- a/data/initrd/scripts/remote_log_setup
+++ b/data/initrd/scripts/remote_log_setup
@@ -1,0 +1,12 @@
+#! /bin/bash
+#USAGE: requires the LOGHOST variable to be set
+
+#set loghost
+echo "*.*@${LOGHOST}:514" > /etc/rsyslog.d/loghost.conf
+
+echo -n "starting rsyslogd (logging to /var/log/messages)..."
+if /usr/sbin/rsyslogd ; then
+  echo " ok"
+else
+  echo " failed"
+fi

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -91,18 +91,6 @@ for i in /update/[0-9]*/install/update.pre ; do
   [ -x "$i" ] && "$i"
 done
 
-# start syslogd
-if [ -x /usr/sbin/syslogd ] ; then
-  checkproc /usr/sbin/syslogd || {
-    echo -n "starting syslogd (logging to /var/log/messages)..."
-    if /usr/sbin/syslogd ; then
-      echo " ok"
-    else
-      echo " failed"
-    fi
-  }
-fi
-
 # start klog
 if [ -x /sbin/klogd ] ; then
   checkproc /sbin/klogd || {


### PR DESCRIPTION
now the preferred logger is rsyslog so syslog was removed completely

It works, but it still needs refactoring:
1) removing ugly output during nscd start 

And more features:
1) reflect changes on rescue image as well
2) log more files


Implements https://fate.suse.com/318971