### PR TITLE
adjust dud directory calculation to new tumbleweed os-release format (bsc #1012241)

### DIFF
--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -11,7 +11,7 @@ BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://opensuse.org/"
 ID_LIKE="suse"
 
-== tumbleweed ==
+== tumbleweed (old) ==
 
 NAME=openSUSE
 VERSION="Tumbleweed"
@@ -23,6 +23,19 @@ CPE_NAME="cpe:/o:opensuse:opensuse:20160126"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
 ID_LIKE="suse"
+
+== tumbleweed ==
+
+NAME="openSUSE Tumbleweed"
+# VERSION="20161125"
+ID=opensuse
+ID_LIKE="suse"
+VERSION_ID="20161125"
+PRETTY_NAME="openSUSE Tumbleweed"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:tumbleweed:20161125"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
 
 == leap ==
 

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -855,6 +855,7 @@ sub get_version_info
   my $f;
   my %config;;
 
+  $file = "${BasePath}tmp/base/usr/lib/os-release" if -f "${BasePath}tmp/base/usr/lib/os-release";
   if(open $f, $file) {
     while(<$f>) {
       $config{$1} = $2 if /^([^\s=]+)\s*=\s*\"?(.*?)\"?\s*$/;
@@ -892,7 +893,9 @@ sub get_version_info
   # don't accept other names than these
   $dist = "" if $dist !~ /^(leap|sles|sled)$/;
 
-  $dist .= $config{VERSION} eq 'Tumbleweed' ? 'tw' : $config{VERSION_ID};
+  my $is_tw = $config{VERSION} eq 'Tumbleweed' || $config{CPE_NAME} =~ /:tumbleweed:/;
+
+  $dist .= $is_tw ? 'tw' : $config{VERSION_ID};
   $dist =~ s/\..*$// if $dist =~ /^(sles|sled)/;
 
   # print "dist=\"$dist\"\n";


### PR DESCRIPTION
For whatever reason the /etc/os-release content has changed for tumbleweed
(compare tw entries in os_sample.txt). Adjust parser to new entries.