### PR TITLE
update module.config to match 4.10

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -650,7 +650,7 @@ ioc3
 ipwireless
 iscsi_trgt
 joydev
-kvm
+kernel/arch/.*/kvm/kvm
 monreader
 msdos
 parport_ax88796
@@ -666,6 +666,7 @@ ppp_synctty
 pppoe
 prism2_usb
 pt
+scr24x_cs
 serial_cs
 slip
 tape_3590


### PR DESCRIPTION
4.10 added `scr24x_cs`, so add it to the list along with other unneeded
PCMCIA drivers.

kvm cannot be found by the scripts:
```
  error: no useful config for "kvm" (needed by kvm)
```
so hint it with a path.