### PR TITLE
zypp.conf is really in initrd, so modify it there

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -116,6 +116,13 @@ linuxrc:
 # add zypp config to initrd to ensure it's writable
 libzypp: nodeps
   /etc
+  if theme eq 'CASP'
+    # patch /etc/zypp/zypp.conf (fate #321764); sets
+    # solver.onlyRequires = true, rpm.install.excludedocs = yes, multiversion =
+    R s/^[#[:space:]]*(solver.onlyRequires)\s+=.*/# minimal CASP\n$1 = true/ etc/zypp/zypp.conf
+    R s/^[#[:space:]]*(rpm.install.excludedocs)\s+=.*/# minimal CASP\n$1 = yes/ etc/zypp/zypp.conf
+    R s/^[#[:space:]]*(multiversion)\s+=.*/# minimal CASP\n$1 =/ etc/zypp/zypp.conf
+  endif
 
 sharutils:
   /usr/bin/uuencode

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -705,13 +705,8 @@ endif
 d /usr/share/libyui/data
 x lang_fonts /usr/share/libyui/data/lang_fonts
 
-if theme eq 'CASP'
-  # patch /etc/zypp/zypp.conf (fate #321764); sets
-  # solver.onlyRequires = true, rpm.install.excludedocs = yes, multiversion =
-  R s/^[#[:space:]]*(solver.onlyRequires)\s+=.*/# minimal CASP\n$1 = true/ etc/zypp/zypp.conf
-  R s/^[#[:space:]]*(rpm.install.excludedocs)\s+=.*/# minimal CASP\n$1 = yes/ etc/zypp/zypp.conf
-  R s/^[#[:space:]]*(multiversion)\s+=.*/# minimal CASP\n$1 =/ etc/zypp/zypp.conf
-endif
+# zypp config is in initrd
+r /etc/zypp
 
 # allowed dangling symlinks
 D ../../sbin/update-ca-certificates /usr/lib64/p11-kit/p11-kit-extract-trust


### PR DESCRIPTION
Well, actually libzypp is **both** in initrd and root image but the first takes precedence.

So we also remove zypp config from root image to save the space.