### PR TITLE
additional log files for FATE#318971

### DIFF
--- a/data/initrd/etc/rsyslog.d/logged_files.conf
+++ b/data/initrd/etc/rsyslog.d/logged_files.conf
@@ -7,3 +7,39 @@ input(type="imfile"
       Tag="yast2_logs"
       Severity="notice"
       Facility="local0")
+
+#linuxrc
+input(type="imfile"
+      File="/var/log/linuxrc.log"
+      Tag="linuxrc"
+      Severity="notice"
+      Facility="local0")
+
+
+#zypp history
+input(type="imfile"
+      File="/var/log/zypp/history"
+      Tag="zypp_history"
+      Severity="notice"
+      Facility="local0")
+
+#pk_backend_zypp
+input(type="imfile"
+      File="/var/log/pk_backend_zypp"
+      Tag="pk_backend_zypp"
+      Severity="notice"
+      Facility="local0")
+
+#zypp log
+input(type="imfile"
+      File="/var/log/zypper.log"
+      Tag="zypper"
+      Severity="notice"
+      Facility="local0")
+
+#pbl
+input(type="imfile"
+      File="/var/log/pbl.log"
+      Tag="pbl"
+      Severity="notice"
+      Facility="local0")


### PR DESCRIPTION
Loghost now sends also linuxrc, zypp's history, pk_backend_zypp,
zypper.log, pbl.log, /.packages.root.

All the files have distinct tags to allow filtering on the remote log
server


Asserted only that linuxrc.log  are sent. The rest should be consistent enough to hold.

Log files selected to be consistent with save_y2logs script.