### PR TITLE
make yast selfupdate feature configurable via YAST_SELFUPDATE env variable

### DIFF
--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -77,4 +77,8 @@ e echo "KexecReboot:    1" >>linuxrc.config
 
 e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode" >>linuxrc.config
 
+if YAST_SELFUPDATE ne ""
+  e echo "SelfUpdate:	<YAST_SELFUPDATE>" >>linuxrc.config
+endif
+
 e echo -e "\n# Note: you can put config files also into /etc/linuxrc.d/." >>linuxrc.config


### PR DESCRIPTION
This allows a per-product setting in the spec file and moves this out of linuxrc.