### PR TITLE
Ignore python2-setuptools package instead of python-setuptools

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -81,7 +81,7 @@ nfsidmap: ignore
 pam-config: ignore
 permissions: ignore
 pinentry: ignore
-python-setuptools: ignore
+python2-setuptools: ignore
 sessreg: ignore
 shared-mime-info: ignore
 update-alternatives: ignore


### PR DESCRIPTION
The PR fixes [this OSB build failure](https://build.opensuse.org/package/live_build_log/system:install:head/installation-images:openSUSE/openSUSE_Factory_standard/x86_64):

```
checking for dangling symlinks...
invalid: /usr/bin/easy_install -> /etc/alternatives/easy_install
mk_image: please fix symlinks
```

It seems the package has been renamed.

The package builds in [my testing OBS branch project](https://build.opensuse.org/package/live_build_log/system:install:head/installation-images:openSUSE/openSUSE_Factory_standard/x86_64)