### PR TITLE
etc: update module.config to match 4.11

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -128,6 +128,7 @@ lis3lv02d,-,-
 bcma
 caif_hsi
 ptp
+ptp_kvm
 ptp_pch
 pps_core
 gpio-cs5535
@@ -297,6 +298,7 @@ rionet
 rrunner,"Essential RoadRunner HIPPI"
 slhc,"compress and uncompress tcp packets"
 spidernet,"Spider Southbridge Gigabit Ethernet"
+tap
 virtio_net,"Virtio network"
 vmxnet3,VMware vmxnet3 virtual NIC
 xen-vnif,"Xen Network"


### PR DESCRIPTION
4.11 added tap and ptp_kvm, so add it to the list:

- tap near macvlan which needs it
- ptp_kvm near other ptp modules