### PR TITLE
anticipate openssl repackaging

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -359,7 +359,11 @@ cracklib: nodeps
   x etc/ssh /lib
   x ../rescue/mount-rootfs-and-do-chroot.sh /bin
 
-openssl:
+if exists(openssl, /usr/share/ssl)
+  openssl:
+else
+  openssl-*:
+endif
   /usr/share/ssl
 
 nscd:

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -155,12 +155,12 @@ netcfg:
   x etc/ssh /lib
   x ../rescue/mount-rootfs-and-do-chroot.sh /bin
 
-openssl:
+if exists(openssl, /usr/share/ssl)
+  openssl:
+else
+  openssl-*:
+endif
   /usr/share/ssl
-
-libopenssl*:
-  /lib*/libcrypto.so.*
-  /lib*/libssl.so.*
 
 dmidecode:
   /usr/sbin/dmidecode


### PR DESCRIPTION
openssl has been split into openssl (dummy) and openssl-VERSION.

replaces https://github.com/openSUSE/installation-images/pull/182