### PR TITLE
etc: update module.config to match 4.12

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -635,3 +635,4 @@ tun
 veth
 vmwatchdog
 vrf
+vsockmon


### PR DESCRIPTION
4.12 added vsockmon, so add it to the list of [notuseful]. Citing from
the kernel:
>     It is mostly intended for developers or support to debug vsock
>     issues.