### PR TITLE
include video drivers from drm-kmp (bsc #1043146)

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -37,7 +37,7 @@ s390    = kernel-s390
 [KMP]
 default	=
 i386	= virtualbox-guest,xen
-x86_64	= virtualbox-guest,xen
+x86_64	= virtualbox-guest,xen,drm
 
 
 ; extra firmware packages

--- a/etc/module.config
+++ b/etc/module.config
@@ -199,6 +199,7 @@ kernel/net/phonet/.*
 kernel/drivers/gpu/.*
 kernel/net/ceph/.*
 kernel/net/802/.*
+updates/drivers/gpu/.*
 
 
 ; acpi


### PR DESCRIPTION
The new video drivers are provided as separate kmp for sle12-sp3/leap-42.3.
This patch just supports this setup. The actual decision whether to include
the drm kmp is made in the spec file.