### PR TITLE
run udev prein script in initrd (bsc #1047598)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -432,6 +432,7 @@ openssh: nodeps
 
 udev:
   /
+  E prein
   E groupadd -r tape
 
 # we just want the user & group entries


### PR DESCRIPTION
The script generates /usr/lib/udev/compat-symlink-generation which
influences symlink generation.