### PR TITLE
always load dm_multipath module

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -251,6 +251,7 @@ arc4
 snd_seq
 snd_pcm_oss
 8021q
+dm-multipath
 
 
 [IDE/RAID/SCSI]


### PR DESCRIPTION
It is required for multipath detection anyway, so we might as well load it
unconditionally during startup.