### PR TITLE
Fix the default cursor theme (bsc#1051664)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -562,7 +562,7 @@ arabic-kacst-fonts:
   /usr/share/fonts/truetype/KacstBook.ttf
 
 dmz-icon-theme-cursors:
-  /usr/share/icons/DMZ
+  /usr/share/icons/DMZ-White
 
 multipath-tools:
   /sbin


### PR DESCRIPTION
- Fixes https://bugzilla.suse.com/show_bug.cgi?id=1051664
- The icon theme path has been changed, the `dmz-icon-theme-cursors` package now contains two themes/directories: `DMZ-White` and `DMZ-Black`.
- See https://build.opensuse.org/package/view_file/openSUSE:Factory/dmz-icon-theme-cursors/dmz-icon-theme-cursors.spec?expand=1