### PR TITLE
Kubic needs to be have the same zypp.conf as CaaSP

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -116,7 +116,7 @@ linuxrc:
 # add zypp config to initrd to ensure it's writable
 libzypp: nodeps
   /etc
-  if theme eq 'CAASP'
+  if (theme eq 'CAASP') || (theme eq 'Kubic')
     # patch /etc/zypp/zypp.conf (fate #321764); sets
     # solver.onlyRequires = true, rpm.install.excludedocs = yes, multiversion =
     R s/^[#[:space:]]*(solver.onlyRequires)\s+=.*/# minimal CAASP\n$1 = true/ etc/zypp/zypp.conf


### PR DESCRIPTION
Kubic needs to have the same zypp.conf on the media as CaaSP - wasn't sure about the syntax of the file_list but it seems perl-like so I took my best stab at it.

Needed to resolve boo#1057854, which is blocking Kubic from installing a system correctly.