### PR TITLE
include all mouse drivers (bsc #1055628)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -43,7 +43,6 @@ agpgart,-,-
 ali-agp,-,-
 amd-k7-agp,-,-
 amd64-agp,-,-
-appletouch,"Apple PowerBook Touchpad",-
 ati-agp,-,-
 binfmt_misc
 blkcipher,-,-
@@ -182,6 +181,7 @@ kernel/drivers/crypto/.*
 kernel/drivers/.*/crypto/.*
 kernel/drivers/firmware/.*
 kernel/drivers/i2c/.*
+kernel/drivers/input/mouse/.*
 kernel/drivers/leds/.*
 kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/md/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -16,8 +16,7 @@ kernel/drivers/firewire/
 # kernel/drivers/input/
 -kernel/drivers/input/joystick
 -kernel/drivers/input/gameport
-kernel/drivers/input/mouse/psmouse.ko
-kernel/drivers/input/mouse/appletouch.ko
+kernel/drivers/input/mouse/
 kernel/drivers/input/serio/hyperv-keyboard.ko
 kernel/drivers/input/input-polldev.ko
 kernel/drivers/iseries/


### PR DESCRIPTION
Apparently elan_i2c.ko was missing in this bug. But let's include all driver
modules (9) from kernel/drivers/input/mouse to be on the safe side.