### PR TITLE
use the same driver updates for caasp as the dist it is based on

### DIFF
--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -143,3 +143,23 @@ ID="caasp"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:suse:caasp:1.0"
 
+== caasp20 ==
+
+NAME="CAASP"
+VERSION="2.0"
+VERSION_ID="2.0"
+PRETTY_NAME="SUSE Container as a Service Platform 2.0"
+ID="caasp"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:caasp:2.0"
+
+== caasp30 ==
+
+NAME="CAASP"
+VERSION="3.0"
+VERSION_ID="3.0"
+PRETTY_NAME="SUSE CaaS Platform 3.0"
+ID="caasp"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:caasp:3.0"
+

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -899,8 +899,15 @@ sub get_version_info
 
   my $is_tw = $dist =~ /^tumbleweed( kubic)?$/;
 
+  # kubic uses 'tw' as dist tag
   $dist = $is_tw ? 'tw' : "$dist$config{VERSION_ID}";
+
+  # there's no separate dist tag for service packs
   $dist =~ s/\..*$// if $dist =~ /^(sles|sled)/;
+
+  # caasp uses the dist it is based on (except for caasp1.0)
+  $dist = "sle12" if $dist eq "caasp2.0";
+  $dist = "sle15" if $dist eq "caasp3.0";
 
   # print "dist=\"$dist\"\n";
 


### PR DESCRIPTION
Thorsten (kukuk) requested that caasp (> 1.0) should use the same dir for
driver updates as the sle release it is based on.