### PR TITLE
add 'qemu' url scheme

### DIFF
--- a/data/initrd/scripts/url/qemu/menu
+++ b/data/initrd/scripts/url/qemu/menu
@@ -1,0 +1,1 @@
+QEMU Firmware Interface

--- a/data/initrd/scripts/url/qemu/mount
+++ b/data/initrd/scripts/url/qemu/mount
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+# https://github.com/openSUSE/linuxrc/blob/master/user_defined_url_schemes.txt
+
+fw_base=/sys/firmware/qemu_fw_cfg
+
+set -e
+
+echo "url_dir = '$url_dir'"
+
+if [ -d "$url_dir" -a -d $fw_base ] ; then
+  mount --bind $fw_base  "$url_dir"
+else
+  exit 1
+fi
+


### PR DESCRIPTION
Use, e.g.
```
info=qemu:/by_name/opt/oss/foo/raw
```
to access data injected into qemu with
```
-fw_cfg name=opt/oss/foo,file=/tmp/foo.txt
```
Note the `/by_name` prefix and the `/raw` suffix.