### PR TITLE
squashfs.ko might depend on zstd_decompress

### DIFF
--- a/gefrickel
+++ b/gefrickel
@@ -38,7 +38,7 @@ lib_dir=${lib_dir%%/*}
 m_dir=`echo lib/modules/*/initrd`
 [ -d "$m_dir" ] || err "no kernel module dir"
 mkdir -p "b/$m_dir"
-for i in loop squashfs lz4_decompress ; do
+for i in loop squashfs lz4_decompress xxhash zstd_decompress; do
   [ -f $m_dir/$i.ko ] && mv $m_dir/$i.ko b/$m_dir
 done
 mkdir -p a/lib


### PR DESCRIPTION
Since kernel 4.14, we see:
```
 squashfs: Unknown symbol ZSTD_DStreamWorkspaceBound (err 0)
 squashfs: Unknown symbol ZSTD_decompressStream (err 0)
 squashfs: Unknown symbol ZSTD_initDStream (err 0)
```
So add the dependencies to the image to be able to decompress the
squashfs images.