### PR TITLE
Adjust for new fillup-templates location (boo#1069468)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -134,7 +134,7 @@ gawk:
 :
 
 # remove things we don't need
-r /usr/share/doc /usr/share/info /usr/share/man /var/adm/fillup-templates
+r /usr/share/doc /usr/share/info /usr/share/man /usr/share/fillup-templates /var/adm/fillup-templates
 
 # remove compat service links
 E rm -f `find usr/sbin -lname service`

--- a/data/initrd/biostest.file_list
+++ b/data/initrd/biostest.file_list
@@ -31,7 +31,7 @@ powertop:
 :
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 
 e ldconfig -r .
 

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -383,8 +383,8 @@ systemd:
 
 sysconfig:
   /
-  m /var/adm/fillup-templates/sysconfig.config-network /etc/sysconfig/network/config
-  m /var/adm/fillup-templates/sysconfig.dhcp-network /etc/sysconfig/network/dhcp
+  m /usr/share/fillup-templates/sysconfig.config-network /etc/sysconfig/network/config
+  m /usr/share/fillup-templates/sysconfig.dhcp-network /etc/sysconfig/network/dhcp
   r sbin/rcnetwork
 
 ?fcoe-utils:
@@ -581,7 +581,7 @@ endif
 R s/ Server//g etc/issue
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 r /etc/passwd?* /etc/shadow?* /etc/group?*
 r /etc/profile.d
 if arch ne 's390' && arch ne 's390x'

--- a/data/rescue/rescue-server.file_list
+++ b/data/rescue/rescue-server.file_list
@@ -17,7 +17,7 @@ r media/*
 d media/repo
 
 # remove unnecessary files
-r /usr/share/doc /usr/share/info /usr/share/man /var/adm/fillup-templates
+r /usr/share/doc /usr/share/info /usr/share/man /usr/share/fillup-templates /var/adm/fillup-templates
 
 # enable services
 s ../vsftpd.service usr/lib/systemd/system/multi-user.target.wants

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -367,7 +367,7 @@ R s/product_name/<product_name>/g /etc/issue
 R s/ Server//g etc/issue
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 r dev/mapper dev/stderr dev/initctl
 
 # remove grub2 *.module files, they're not needed

--- a/data/root/bind.file_list
+++ b/data/root/bind.file_list
@@ -16,4 +16,4 @@ AUTODEPS:
 :
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates

--- a/data/root/gdb.file_list
+++ b/data/root/gdb.file_list
@@ -13,4 +13,4 @@ x gdb.init .init
 x gdb.done .done
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates

--- a/data/root/libstoragemgmt.file_list
+++ b/data/root/libstoragemgmt.file_list
@@ -16,4 +16,4 @@ x libstoragemgmt.init .init
 x libstoragemgmt.done .done
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -429,7 +429,7 @@ timezone:
 if !(arch eq 's390' || arch eq 's390x')
   kbd:
     /
-    m /var/adm/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
+    m /usr/share/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
 endif
 
 if roottrans
@@ -648,7 +648,7 @@ e mkfontdir usr/share/fonts/truetype
 r /etc/os-release
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 r /etc/profile.d /etc/profile /etc/bash.bashrc /etc/bash_completion.d
 r /run /var/log/{cache,games,log,lock,mail,opt,spool} /var/run
 r /var/lib/systemd/migrated

--- a/data/root/snapper.file_list
+++ b/data/root/snapper.file_list
@@ -10,4 +10,4 @@ AUTODEPS:
 :
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,locale,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -223,13 +223,13 @@ rsyslog:
 r /usr/share/locale
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 
 # remove /etc/os-release so it's not used accidentally
 r /etc/os-release
 
 # remove files we don't want to show up at all
-r /usr/share/{doc,info,man} /usr/src/packages /var/adm/fillup-templates
+r /usr/share/{doc,info,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 r /etc/profile.d /etc/profile /etc/bash.bashrc /etc/bash_completion.d
 r /run /var/log/{cache,games,log,lock,mail,opt,spool} /var/run
 r /var/lib/systemd/migrated


### PR DESCRIPTION
As discussed this morning, this change fixes the problems found this morning.

The impacted packages are only `sysconfig` and `kbd` (in stagings H and L currently), which is why we didn't hit the problem with the other dozens of packages already in factory. 

@DimStar77 knows to stage this change with those packages, so please get an OBS submission to him as quickly as possible.

This change adds the new location to all of the "removes" that used to reference /var/adm/fillup-templates - the old location is preserved because some packages are not yet using the new location. 

I'll make a note to follow this up when we remove the backwards compatibility from the rpm fillup macros.