### PR TITLE
create groups needed in inst-sys (bsc #1064822)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -328,7 +328,7 @@ nscd:
   d /var/run/nscd
 
 ?virtualbox-guest-tools: nodeps
-  /usr/lib/udev
+  /etc/udev
 
 ?xf86-input-vmmouse: nodeps
   /usr/lib/udev/rules.d
@@ -435,10 +435,13 @@ openssh: nodeps
   E prein
   d etc/ssh
 
+system-group-hardware:
+  /
+  E prein
+
 udev:
   /
   E prein
-  E groupadd -r tape || true
 
 # we just want the user & group entries
 polkit: nodeps
@@ -450,7 +453,7 @@ nscd:
 
 # we just want the user & group entries
 rpcbind:
-  /var/lib
+  E groupadd -r nobody || true
   E prein
 
 # we just want the user & group entries

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -452,6 +452,7 @@ nscd:
   E prein
 
 # we just want the user & group entries
+# FIXME: assumes nobody group exists - maybe time to drop rpcbind?
 rpcbind:
   E groupadd -r nobody || true
   E prein


### PR DESCRIPTION
... and some other small package adjustments.

Groups are created in pre-install of system-group-hardware meanwhile.

And some packages have moved around their files a bit.