### PR TITLE
allow dangling machine-id symlink (bsc #1027200)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -423,3 +423,4 @@ d usr/lib/microcode
 D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
 D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list
+D /etc/machine-id /var/lib/dbus/machine-id


### PR DESCRIPTION
/etc/machine-id is expected to be created at first startup.