### PR TITLE
simplify definitions for libstoragemgmt image

### DIFF
--- a/data/root/libstoragemgmt.file_list
+++ b/data/root/libstoragemgmt.file_list
@@ -2,11 +2,8 @@ TEMPLATE:
   /
 
 libstoragemgmt:
-python-libstoragemgmt:
-libstoragemgmt1:
 libstoragemgmt-netapp-plugin:
 libstoragemgmt-smis-plugin:
-?python-argparse:
 
 AUTODEPS:
 


### PR DESCRIPTION
This removes explicit package dependencies as much as possible.