### PR TITLE
make cypto lib dependencies more flexible

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -53,6 +53,7 @@ TEMPLATE:
 
 AUTODEPS:
 
+bash:
 ca-certificates-mozilla:
 coreutils:
 cpio:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -266,7 +266,7 @@ gpg2:
   d root/.gnupg
 
 cryptsetup:
-?libcryptsetup4-hmac:
+?libcryptsetup*-hmac:
 ?libgcrypt20-hmac:
 
 ntfs-3g:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -89,8 +89,6 @@ cpio:
 cracklib-dict-full:
 cracklib:
 cryptsetup:
-?libcryptsetup4-hmac:
-?libgcrypt20-hmac:
 curl:
 dd_rescue:
 diffutils:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -122,7 +122,7 @@ cpio:
 # Do not remove cryptsetup even though it's also listed in initrd.file_list
 # because of the dropped dependency to cracklib-dict-xxx in the initrd.
 cryptsetup:
-?libcryptsetup4-hmac:
+?libcryptsetup*-hmac:
 device-mapper:
 dmraid:
 dosfstools:


### PR DESCRIPTION
The catch is that nobody really _requires_ those *-hmac packages. Except in
the rescue system where dracut-fips requires them - so there we can drop the
explicit dependencies.