### PR TITLE
mk_image: /var/lib/rpm/alternatives was moved to /var/lib/alternatives

### DIFF
--- a/bin/mk_image
+++ b/bin/mk_image
@@ -241,7 +241,7 @@ sub fix_alternatives_link
     unlink "$dir/usr/sbin/alternatives";
     unlink "$dir/var/log/update-alternatives.log";
     system "rm -r $dir/etc/alternatives/";
-    system "rm -r $dir/var/lib/rpm/alternatives/";
+    system "rm -rf $dir/var/lib{/rpm,}/alternatives/";
   }
 }
 


### PR DESCRIPTION
Handle the new path as well

This is just a 'feel right' while looking for something totally unrelated to fix