### PR TITLE
remove default driver update url (bsc #1084510)

### DIFF
--- a/data/boot/theme.file_list
+++ b/data/boot/theme.file_list
@@ -5,7 +5,7 @@ if arch eq 'i386' || arch eq 'x86_64'
   gfxboot-branding-<gfxboot_theme>:
     /
     e cp -a etc/bootsplash/themes/<gfxboot_theme>/cdrom/* loader
-    e gfxboot --config-file=loader/gfxboot.cfg --change-config install::dud.url=http://download.opensuse.org/update/openSUSE/driverupdate
+    # e gfxboot --config-file=loader/gfxboot.cfg --change-config install::dud.url=http://download.opensuse.org/update/openSUSE/driverupdate
     e gfxboot --config-file=loader/gfxboot.cfg --change-config product="<product_name>"
     e gfxboot --config-file=loader/gfxboot.cfg --change-config mainmenu.title="<product_name>"
 


### PR DESCRIPTION
The URL does no longer exist (and there's no agreed-on location anyway).