### PR TITLE
move tftpboot location (bsc #1085479)

### DIFF
--- a/install.aarch64
+++ b/install.aarch64
@@ -31,7 +31,7 @@ mkdir -p $DESTDIR/usr/share
 cp images/mini-iso-rmlist $DESTDIR/usr/share
 
 if [ -d images/tftp ] ; then
-  dst=$DESTDIR/srv/tftpboot
+  dst=$DESTDIR/usr/share/tftpboot-installation
   mkdir -p $dst
   cp -a images/tftp/* $dst
   cp -a $DESTDIR/CD1/* $dst/*

--- a/install.i386
+++ b/install.i386
@@ -92,7 +92,7 @@ if [ -f images/zenroot ] ; then
 fi
 
 if [ -d images/tftp ] ; then
-  dst=$DESTDIR/srv/tftpboot
+  dst=$DESTDIR/usr/share/tftpboot-installation
   mkdir -p $dst
   cp -a images/tftp/* $dst
   cp -a $DESTDIR/CD1/* $dst/*

--- a/install.ppc
+++ b/install.ppc
@@ -40,7 +40,7 @@ mkdir -p $DESTDIR/usr/share
 cp images/mini-iso-rmlist $DESTDIR/usr/share
 
 if [ -d images/tftp ] ; then
-  dst=$DESTDIR/srv/tftpboot
+  dst=$DESTDIR/usr/share/tftpboot-installation
   mkdir -p $dst
   cp -a images/tftp/* $dst
   cp -a $DESTDIR/CD1/* $dst/*

--- a/install.s390x
+++ b/install.s390x
@@ -46,7 +46,7 @@ mkdir -p $DESTDIR/usr/share
 cp images/mini-iso-rmlist $DESTDIR/usr/share
 
 if [ -d images/tftp ] ; then
-  dst=$DESTDIR/srv/tftpboot
+  dst=$DESTDIR/usr/share/tftpboot-installation
   mkdir -p $dst
   cp -a images/tftp/* $dst
   cp -a $DESTDIR/CD1/* $dst/*


### PR DESCRIPTION
Moved from /srv/tftpboot to /usr/share/tftpboot-installation.