### PR TITLE
remove last mozilla-nspr reference

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -149,7 +149,6 @@ libyui-qt-pkg*:
 libyui-qt-graph*:
 ?ltrace:
 lvm2:
-mozilla-nspr:
 multipath-tools:
 net-tools:
 ?net-tools-deprecated:


### PR DESCRIPTION
The line was just forgotten in https://github.com/openSUSE/installation-images/pull/244.