### PR TITLE
adjusted libopenssl*_*-hmac dependency to match current versions (bsc#1090360)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -426,7 +426,7 @@ dbus-1:
 
 # For FIPS installation:
 
-libopenssl*_*_*-hmac:
+libopenssl*_*-hmac:
 
 ?openssh-fips:
 ?openssh-hmac:


### PR DESCRIPTION
[bsc#1090360](https://bugzilla.suse.com/show_bug.cgi?id=1090360)