### PR TITLE
include all kernel input modules (bsc #1095289)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -65,8 +65,6 @@ hpfs
 hwmon,-,-
 i460-agp,-,-
 ide-scsi,-,-,,,1
-input-polldev,,-
-hyperv-keyboard,,-
 intel-agp,-,-
 iscsi_boot_sysfs
 kernel/drivers/mfd/.*,,-
@@ -105,7 +103,6 @@ sgi-agp,-,-
 sis-agp,-,-
 snd
 soundcore
-sparse-keymap
 ssb
 st,-SCSI Tape Driver,-
 sunrpc,-,-
@@ -160,8 +157,6 @@ geneve
 
 fjes
 
-xen-fbfront
-xen-kbdfront
 xen-netback
 xen-netfront
 xen-pcifront
@@ -183,7 +178,7 @@ kernel/drivers/crypto/.*
 kernel/drivers/.*/crypto/.*
 kernel/drivers/firmware/.*
 kernel/drivers/i2c/.*
-kernel/drivers/input/mouse/.*
+kernel/drivers/input/.*
 kernel/drivers/leds/.*
 kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/md/.*
@@ -621,7 +616,6 @@ ifb
 ioc3
 ipwireless
 iscsi_trgt
-joydev
 msdos
 parport_ax88796
 parport_cs

--- a/etc/module.list
+++ b/etc/module.list
@@ -13,12 +13,9 @@ kernel/drivers/ide/
 kernel/drivers/ata/
 #-kernel/drivers/ata/pata_
 kernel/drivers/firewire/
-# kernel/drivers/input/
+kernel/drivers/input/
 -kernel/drivers/input/joystick
 -kernel/drivers/input/gameport
-kernel/drivers/input/mouse/
-kernel/drivers/input/serio/hyperv-keyboard.ko
-kernel/drivers/input/input-polldev.ko
 kernel/drivers/iseries/
 kernel/drivers/md/
 kernel/drivers/mmc/
@@ -47,7 +44,6 @@ kernel/drivers/usb/serial/
 kernel/drivers/usb/input/usbhid.ko
 kernel/drivers/hid/
 -kernel/drivers/hid/hid-prodikeys.ko
-kernel/drivers/input/ff-memless.ko
 kernel/drivers/char/nvram.ko
 kernel/drivers/char/agp/
 kernel/drivers/message/fusion/
@@ -109,7 +105,6 @@ kernel/drivers/mfd/
 kernel/drivers/cpufreq/
 kernel/arch/x86/kernel/
 kernel/drivers/platform/
-kernel/drivers/input/sparse-keymap.ko
 kernel/drivers/pci/hotplug/pci_hotplug.ko
 kernel/sound/soundcore.ko
 kernel/sound/core/snd.ko
@@ -156,7 +151,6 @@ kernel/drivers/xen/netfront/
 kernel/drivers/xen/core/
 kernel/drivers/xen/xen-scsiback.ko
 kernel/drivers/video/fbdev/xen-fbfront.ko
-kernel/drivers/input/misc/xen-kbdfront.ko
 
 kernel/net/ieee80211/
 


### PR DESCRIPTION
Giving up on tracking useful input modules individually. With this patch
all are included except joystick and gameport modules (which I seriously hope
nobody will miss).