### PR TITLE
Add mailbox modules (boo#1040492)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -7,16 +7,16 @@
 ;        modules are added to the section)
 ;   (3)  a parameter starting with '-' indicates that linuxrc should never
 ;        prompt the user for module params, even in manual mode; instead, this
-;        param (without the '-' is used)
+;        param (without the '-') is used
 ;   (4)  modules starting with '-' are not added, but the config entry is kept
 ;   (5)  module dependencies are added to pre_install automatically
 ;   (6)  don't assign a module to more than one section (with the exception of
 ;        'cd1' and 'autoload')
 ;   (7)  you can have modules in section 'autoload' _and_ in another section;
-;        it will be auomatically loaded and be available via menu in linuxrc,
+;        it will be automatically loaded and be available via menu in linuxrc,
 ;        too in this case
 ;   (8)  section 'cd1' holds the list of modules that are put on CD1; they
-;        are loaded by yast, if necessary and don't need any special config
+;        are loaded by yast, if necessary, and don't need any special config
 ;        line
 ;   (9)  A section, MoreModules and ModuleClass may have "@label" in it.
 ;        Both are removed in the final config. This can be used to split a

--- a/etc/module.config
+++ b/etc/module.config
@@ -181,6 +181,7 @@ kernel/drivers/i2c/.*
 kernel/drivers/input/.*
 kernel/drivers/leds/.*
 kernel/drivers/usb/core/ledtrig-usbport.ko
+kernel/drivers/mailbox/.*
 kernel/drivers/md/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -242,6 +242,7 @@ kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/phy/
 kernel/drivers/regulator/
 kernel/drivers/pci/host/
+kernel/drivers/mailbox/
 
 kernel/fs/efivarfs/
 


### PR DESCRIPTION
The HiKey board (Hi6220 SoC) needs hi6220-mailbox driver.

While at it, polish the comments explaining module.config syntax.