### PR TITLE
add bcm43xx-firmware (bsc #1099327)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -69,6 +69,7 @@ else
 endif
 
 ?biosdevname:
+?bcm43xx-firmware: nodeps
 cpio:
 cracklib-dict-full: ignore
 curl:


### PR DESCRIPTION
With 'nodeps' as the package requires kernel-firmware which we don't want
here.