### PR TITLE
etc: update module.config to match 4.18

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -165,6 +165,7 @@ xen-scsiback
 
 virtio_blk
 virtio_net
+net_failover
 virtio_scsi
 
 kernel/drivers/infiniband/.*
@@ -619,6 +620,7 @@ ioc3
 ipwireless
 iscsi_trgt
 msdos
+netdevsim
 parport_ax88796
 parport_cs
 parport_serial


### PR DESCRIPTION
4.18 added net_failover which is needed by virtio_net. So add the former
along the latter.

We enabled netdevsim in 4.18, so add it as "notuseful" as it is only for
testing purposes.