### PR TITLE
Rpi iso

### DIFF
--- a/bin/hdimage
+++ b/bin/hdimage
@@ -297,7 +297,7 @@
         close W1;
         if($self->{fs} eq 'fat') {
           my $x = " -n '$self->{label}'" if $self->{label} ne "";
-          system "mkfs.vfat -h $pt_size$x $f >/dev/null";
+          system "mkfs.vfat -s 1 -h $pt_size$x $f >/dev/null";
 
           my ($fat, $boot);
 

--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -45,8 +45,11 @@ endif
 # Add RPi packages if available
 if exists(raspberrypi-firmware)
   raspberrypi-firmware:
+    /
   raspberrypi-firmware-config:
+    /
   raspberrypi-firmware-dt:
+    /
   u-boot-rpi3:
     /
   e mv boot/vc/* .

--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -41,3 +41,14 @@ if arch eq 'x86_64' || arch eq 'aarch64'
     R s/^with_gfx=0/with_gfx=1/ EFI/BOOT/grub.cfg
     R s/THEME/<grub2_theme>/g EFI/BOOT/grub.cfg
 endif
+
+# Add RPi packages if available
+if exists(raspberrypi-firmware)
+  raspberrypi-firmware:
+  raspberrypi-firmware-config:
+  raspberrypi-firmware-dt:
+  u-boot-rpi3:
+    /
+  e mv boot/vc/* .
+  r /boot /usr
+endif


### PR DESCRIPTION
With these patches we extend the installation EFI image with all bits required to boot a Raspberry Pi. With this and a few changes to the iso creation we can then boot a Raspberry Pi directly using the installation iso.