### PR TITLE
aarch64: add gpio-thunderx.ko module (bsc #1106114)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -131,6 +131,7 @@ ptp_kvm
 ptp_pch
 pps_core
 gpio-cs5535
+gpio-thunderx
 libore
 virtio_pci,-,-,,virtio_blk virtio_net virtio_balloon 
 ac97_bus

--- a/etc/module.config
+++ b/etc/module.config
@@ -188,6 +188,7 @@ kernel/drivers/md/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*
 kernel/drivers/platform/.*
+kernel/drivers/regulator/.*
 kernel/drivers/base/regmap/.*
 kernel/drivers/video/.*
 kernel/drivers/virtio/.*
@@ -605,7 +606,6 @@ cm4040_cs
 cuse
 dummy
 eql
-fixed
 gtp
 hyper-v.suse_kmp_dummy
 i2o_bus

--- a/etc/module.list
+++ b/etc/module.list
@@ -245,6 +245,7 @@ kernel/drivers/nvdimm/
 kernel/drivers/usb/dwc2/
 kernel/drivers/usb/dwc3/
 kernel/drivers/usb/core/ledtrig-usbport.ko
+kernel/drivers/regulator/
 
 kernel/fs/efivarfs/
 

--- a/etc/module.list
+++ b/etc/module.list
@@ -204,6 +204,7 @@ kernel/drivers/video/fbdev/hyperv_fb.ko
 kernel/drivers/misc/lis3lv02d/lis3lv02d.ko
 kernel/drivers/misc/cs5535-mfgpt.ko
 kernel/drivers/gpio/gpio-cs5535.ko
+kernel/drivers/gpio/gpio-thunderx.ko
 kernel/drivers/ptp/
 kernel/drivers/pps/pps_core.ko
 kernel/drivers/usb/class/cdc-wdm.ko


### PR DESCRIPTION
This is a backport of https://github.com/openSUSE/installation-images/pull/215 and https://github.com/openSUSE/installation-images/pull/264 to SLE12.