### PR TITLE
pick better fonts for fbiterm (fate #325746)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -126,7 +126,6 @@ cryptsetup:
 device-mapper:
 dosfstools:
 e2fsprogs:
-fbiterm:
 file:
 fillup:
 findutils:
@@ -529,11 +528,17 @@ icewm-lite:
   /usr/bin/icewm-lite
   s /usr/bin/icewm-lite /usr/bin/icewm
 
+# don't include fonts - it prefers /usr/share/fonts/misc anyway
+fbiterm:
+  /usr/bin/fbiterm
+
 dejavu-fonts:
   /usr/share/fonts/truetype/DejaVuSans*.ttf
   r /usr/share/fonts/truetype/DejaVuSansCondensed*
 
 efont-unicode-bitmap-fonts:
+  # fonts used by fbiterm
+  /usr/share/fonts/misc/h16.pcf.gz
   /usr/share/fonts/misc/b16.pcf.gz
 
 ?google-roboto-fonts:


### PR DESCRIPTION
fbiterm's 8x16.pcf is pretty much unreadable. Playing around a bit shows
h16.pcf to be much better suited. As it turns out fbiterm looks for it already.

Even more it prefers fonts in the default system font location
/usr/share/fonts/misc over fonts in its own font directory /usr/share/fbiterm/fonts.

So, including fbiterm fonts has just been a waste of space so far.

This patch adds h16.pcf and removes the fbiterm font directory, saving some space.