### PR TITLE
don't use 'iterm' terminfo (fate#325746)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -53,6 +53,11 @@ TEMPLATE skelcd-control-.*:
   # just a template that does nothing
   d .
 
+# avoid 'iterm' terminfo, instead link to generic 'screen'
+TEMPLATE libiterm.*:
+  /
+  s ../s/screen usr/share/terminfo/i/iterm
+
 TEMPLATE:
   /
 


### PR DESCRIPTION
fbiterm sets TERM to 'iterm' but this leads to display problems in the
ncurses-UI of yast when using an Unicode (iso10646) encoded font as basic
text font.

Not sure why this happens as fbiterm otherwise displays Unicode chars just
fine even in this situation. Looks like 'iterm' does not match fbiterm's
capabilities. Swapping it for 'screen' seems to make it work fine.