### PR TITLE
don't run udevd in its own private fs namespace

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -393,6 +393,7 @@ s /usr/lib/systemd/system/getty@.service etc/systemd/system/getty.target.wants/g
 # don't try to set mount flags
 # it will lead to problems and is not necessary; see bsc #937237 for details
 R s/^MountFlags=slave\s*// usr/lib/systemd/system/systemd-udevd.service
+R s/^PrivateMounts=// usr/lib/systemd/system/systemd-udevd.service
 
 # stripped down kbd init (linuxrc does most)
 x etc/init.d/kbd_simple /etc/init.d/kbd_simple


### PR DESCRIPTION
It's not supported by the rescue system environment because '/' is not
mounted.