### PR TITLE
suse-module-tools now have a dependency on binutils

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -54,6 +54,7 @@ TEMPLATE:
 AUTODEPS:
 
 bash:
+binutils: ignore
 ca-certificates-mozilla:
 coreutils:
 cpio:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -35,6 +35,7 @@ TEMPLATE:
 
 AUTODEPS:
 
+binutils: ignore
 dbus-1-x11: ignore
 diffutils: ignore
 dirmngr: ignore


### PR DESCRIPTION
...which is not wanted. So ignore binutils in more places.