### PR TITLE
udevd needs a mountpoint for / to start (bsc #937237)

### DIFF
--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -74,9 +74,15 @@ if [ -d /mounts/initrd/update ] ; then
   done
 fi
 
-# bash >/dev/console 2>&1
+# ensure there's a mountpoint for /, else udevd will have problems
+# cf. bsc #937237, comment 51
+mount --bind / /
+
+if [ "$startshell" = 1 ] ; then
+  echo "exit shell to continue startup process..."
+  bash >/dev/console 2>&1
+fi
 
 rm -f /mounts/initrd/{*,.*}
 rmdir /mounts/initrd/* 2>/dev/null
 rm -rf /mounts/initrd/{bin,download,etc,lbin,lib,modules,oldroot,root,sbin,scripts,tmp,usr,var}
-

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -393,7 +393,7 @@ s /usr/lib/systemd/system/getty@.service etc/systemd/system/getty.target.wants/g
 # don't try to set mount flags
 # it will lead to problems and is not necessary; see bsc #937237 for details
 R s/^MountFlags=slave\s*// usr/lib/systemd/system/systemd-udevd.service
-R s/^PrivateMounts=// usr/lib/systemd/system/systemd-udevd.service
+R s/^PrivateMounts=.*// usr/lib/systemd/system/systemd-udevd.service
 
 # stripped down kbd init (linuxrc does most)
 x etc/init.d/kbd_simple /etc/init.d/kbd_simple


### PR DESCRIPTION
- fix https://github.com/openSUSE/installation-images/pull/271
- add mountpoint for /
- allow `startshell=1` to interrupt rescue startup process for debugging