### PR TITLE
setctsid is dead, long live setsid (bsc #1109290)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -251,7 +251,7 @@ util-linux:
   /usr/bin/more
   /usr/bin/mount
   /usr/bin/umount
-  /usr/sbin/setctsid
+  /usr/bin/setsid
   /usr/sbin/losetup
   /usr/sbin/blkid
 

--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -14,7 +14,7 @@ if theme eq 'Zen'
     /usr/lib*
 
   e echo "Zen:		2" >>linuxrc.config
-  e echo "SetupCmd:	"\""setctsid \`showconsole\` /bin/bash -c zenworks.s"\" >>linuxrc.config
+  e echo "SetupCmd:	"\""setsid -wc /bin/bash -c zenworks.s"\" >>linuxrc.config
   e echo "Insecure:	1" >>linuxrc.config
 endif
 


### PR DESCRIPTION
setsid's '-c' option does the same as setctsid (set controlling terminal).