### PR TITLE
rescue: change service name of nfsserver to nfs-server

### DIFF
--- a/data/rescue/rescue-server.file_list
+++ b/data/rescue/rescue-server.file_list
@@ -24,7 +24,7 @@ s ../vsftpd.service usr/lib/systemd/system/multi-user.target.wants
 s ../smb.service usr/lib/systemd/system/multi-user.target.wants
 s ../nmb.service usr/lib/systemd/system/multi-user.target.wants
 s ../rpcbind.service usr/lib/systemd/system/multi-user.target.wants
-E chkconfig nfsserver on
+E chkconfig nfs-server on
 
 # add motd
 x /etc/motd /etc/motd


### PR DESCRIPTION
nfs-server is the canonical upstream service name. For a long time,
openSUSE has been shipping a self-crafted service alias as a drop-in