### PR TITLE
s390x: adjust rexx sample script (bsc #1108089, bsc #1108090)

### DIFF
--- a/data/initrd/s390/sles.exec
+++ b/data/initrd/s390/sles.exec
@@ -1,11 +1,11 @@
 /* REXX LOAD EXEC FOR SUSE LINUX S/390 VM GUESTS       */                       
 /* LOADS SUSE LINUX S/390 FILES INTO READER            */                       
 SAY ''                                                                          
-SAY 'LOADING SLES12 FILES INTO READER...'                                       
+SAY 'LOADING SLES FILES INTO READER...'                                         
 'CP CLOSE RDR'                                                                  
 'PURGE RDR ALL'                                                                 
 'SPOOL PUNCH * RDR'                                                             
-'PUNCH SLES12 LINUX A (NOH'                                                     
-'PUNCH SLES12 PARMFILE A (NOH'                                                  
-'PUNCH SLES12 INITRD A (NOH'                                                    
+'PUNCH SLES LINUX A (NOH'                                                       
+'PUNCH SLES PARMFILE A (NOH'                                                    
+'PUNCH SLES INITRD A (NOH'                                                      
 'IPL 00C'                                                                       

--- a/install.s390x
+++ b/install.s390x
@@ -35,7 +35,7 @@ for theme in $THEMES ; do
   install -m 644 data/initrd/s390/parmfile.hmc $DESTDIR/branding/$theme/CD1/boot/$ARCH/parmfile.hmc
   install -m 644 data/initrd/s390/parmfile.cd $DESTDIR/branding/$theme/CD1/boot/$ARCH/parmfile.cd
 
-  install -m 644 data/initrd/s390/sles12.exec $DESTDIR/branding/$theme/CD1/boot/$ARCH/sles12.exec
+  install -m 644 data/initrd/s390/sles.exec $DESTDIR/branding/$theme/CD1/boot/$ARCH/sles.exec
   install -m 644 tmp/base/usr/share/doc/packages/s390-tools/zpxe.rexx $DESTDIR/branding/$theme/CD1/boot/$ARCH/zpxe.rexx
 
   # create cd.ikr and remove no longer needed parmfile.cd


### PR DESCRIPTION
Removing the version and keeping just 'sles' to avoid having to adjust the
script in future.

Note: the lines are (have to be) padded with spaces to 80 chars.