### PR TITLE
Do not set Y2MAXLOGSIZE and Y2MAXLOGNUM in YaST debug mode (bsc#1118643)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -151,8 +151,6 @@ fi
 # for yast debugging.
 if grep -iwq y2debug < /proc/cmdline ; then
   export Y2DEBUG=1
-  export Y2MAXLOGSIZE=50000
-  export Y2MAXLOGNUM=5
 fi
 
 export XCURSOR_THEME=DMZ


### PR DESCRIPTION
Leave that on YaST, it takes the free memory into the account, the default 50MB might be too much on low memory systems.

See https://github.com/yast/yast-installation/blob/93f74ec8ab618922ee6602ed1d40a8ae23407583/startup/First-Stage/F08-logging#L21 (though I'll improve it a bit...)