### PR TITLE
support adding packages matching a regexp (fate #325482)

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -170,6 +170,24 @@ glibc:
 systemd: ignore
 ```
 
+### Including packages matching a regexp
+
+To include a group of packages matching a regexp, use `add_all`:
+
+```
+add_all PACKAGE_REGEXP:
+```
+
+Examples:
+
+```
+add_all skelcd-control-.*:
+```
+
+Note that you cannot associate any actions to such an entry directly. Use
+templates (see below) if you don't want to install the packages as a whole.
+
+
 ### Actions
 
 Several actions can be specified using the following syntax:

--- a/lib/AddFiles.pm
+++ b/lib/AddFiles.pm
@@ -330,6 +330,23 @@ sub AddFiles
 
       $packs->[-1]{rpmdir} = $rpm_dir;
     }
+    elsif(/^add_all\s+(\S+):$/) {
+      my $pattern = $1;
+      my $rpms = RealRPMs $pattern;
+      print "add_all: $pattern = (", join(", ", @$rpms), ")\n";
+      for my $p (@$rpms) {
+        my $rpm_dir = ReadRPM $p;
+
+        next unless $rpm_dir;
+
+        my $entry = {};
+        $entry->{name} = RealRPM($p)->{name};
+        $entry->{version} = ReadFile "$rpm_dir/version";
+        $entry->{rpmdir} = $rpm_dir;
+
+        push @$packs, $entry;
+      }
+    }
     else {
       push @{$packs->[-1]{tasks}}, { src => $src_line, line => $_ };
     }

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -165,7 +165,7 @@ require Exporter;
 @ISA = qw ( Exporter );
 @EXPORT = qw (
   $Script $BasePath $LibPath $BinPath $CfgPath $ImagePath $DataPath
-  $TmpBase %ConfigData ReadFile RealRPM ReadRPM $SUBinary SUSystem Print2File $MToolsCfg $AutoBuild
+  $TmpBase %ConfigData ReadFile RealRPM RealRPMs ReadRPM $SUBinary SUSystem Print2File $MToolsCfg $AutoBuild
   ResolveDeps
 );
 
@@ -319,6 +319,32 @@ sub RealRPM
 
     return $rpmData->{$f} = $rpmData->{$rpm_orig} = { name => $f, file => $n{$f} } ;
   }
+}
+
+
+# Return list of RPMs matching (regexp) pattern. The list is empty if no
+# match was found.
+#
+sub RealRPMs
+{
+  local $_;
+  my $pattern = shift;
+  my @packages;
+
+  if($ConfigData{obs}) {
+    # running outside obs
+    @packages = @{$ConfigData{packages}};
+    # entries in ConfigData are "PACKAGE PROJECT", remove the PROJECT part
+    map { s/\s.*$// } @packages;
+  }
+  else {
+    # running in an obs build
+    @packages = <$ConfigData{suse_base}/*.rpm>;
+    # remove superfluous file name parts
+    map { s#^.*/|\.rpm$##g } @packages;
+  }
+
+  return [ grep { /^$pattern$/ } @packages ];
 }
 
 

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -327,7 +327,6 @@ sub RealRPM
 #
 sub RealRPMs
 {
-  local $_;
   my $pattern = shift;
   my @packages;
 


### PR DESCRIPTION
With 'add_all' it is now possible to add a group of packages. The plan is to
use this with 'skelcd-control-.*' to include all skelcd packages without
having to name them explicitly. The spec file would be responsible to manage
the desired list.