### PR TITLE
add missing drivers for ppc (bsc #1123020)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -522,6 +522,8 @@ pmac,"PowerMac IDE",,,,1
 amd74xx,"JS20 IDE",,,,1
 via82cxxx,"VIA IDE",,,,1
 ; scsi
+aacraid
+kernel/drivers/scsi/megaraid/.*
 sym53c8xx,"Symbios 53c8xx",,,,1
 ipr,"IBM Power Linux RAID adapter",,,,1
 ibmvscsi,"IBM Virtual SCSI",,,,1


### PR DESCRIPTION
Backport of [pr#233](https://github.com/openSUSE/installation-images/pull/233) for SLE12-SP5.