### PR TITLE
Add bcache-tools package

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -119,6 +119,7 @@ yast2-buildtools: nodeps
 
 ?efibootmgr:
 ?elilo:
+bcache-tools:
 btrfsprogs:
 bzip2:
 coreutils:


### PR DESCRIPTION
Needed for PBI: https://trello.com/c/T7taTEix/606-5-use-the-bcache-command-for-probing

Note: installation-images.spec in system:install:head already contains `BuildRequires bcache-tools`.