### PR TITLE
Add bcache-tools package to rescue system

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -68,9 +68,9 @@ else
     /usr/lib*/samba/libwinbind-client*.so
 endif
 
-?bcache-tools:
 ?biosdevname:
 ?bcm43xx-firmware: nodeps
+bcache-tools:
 cpio:
 cracklib-dict-full: ignore
 curl:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -79,6 +79,7 @@ aaa_base-extras:
 attr:
 bash:
 bc:
+bcache-tools:
 bind-utils:
 btrfsprogs:
 bzip2:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -119,7 +119,6 @@ yast2-buildtools: nodeps
 
 ?efibootmgr:
 ?elilo:
-bcache-tools:
 btrfsprogs:
 bzip2:
 coreutils:


### PR DESCRIPTION
Needed for PBI: https://trello.com/c/T7taTEix/606-5-use-the-bcache-command-for-probing