### PR TITLE
remove dependency on pciutils-ids

### DIFF
--- a/data/initrd/biostest.file_list
+++ b/data/initrd/biostest.file_list
@@ -15,9 +15,6 @@ firmwarekit:
 
 pciutils:
 
-pciutils-ids:
-  m /usr/share/pci.ids.d/pci.ids.dist /usr/share/pci.ids
-
 ?acpica:
   /usr/bin/acpixtract
   /usr/bin/iasl

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -243,7 +243,8 @@ pam:
   /
   R s/(pam_unix\.so.*)$/$1 nullok\n/ /etc/pam.d/common-auth
 
-pciutils-ids:
+# keep for compatibility; can be removed if hwdata is used everywhere
+?pciutils-ids:
   m /usr/share/pci.ids.d/pci.ids.dist /usr/share/pci.ids
 
 perl-base:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -394,7 +394,8 @@ shadow:
   /usr/sbin/useradd.local
   d /etc/skel
 
-pciutils-ids:
+# keep for compatibility; can be removed if hwdata is used everywhere
+?pciutils-ids:
   m /usr/share/pci.ids.d/pci.ids.dist /usr/share/pci.ids
 
 checkmedia:

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -177,7 +177,8 @@ sysconfig:
   e echo MODIFY_RESOLV_CONF_DYNAMICALLY=\"yes\" >etc/sysconfig/network/config
   # /sbin/modify_resolvconf
 
-pciutils-ids:
+# keep for compatibility; can be removed if hwdata is used everywhere
+?pciutils-ids:
   m /usr/share/pci.ids.d/pci.ids.dist /usr/share/pci.ids
 
 gawk:


### PR DESCRIPTION
The ids have been moved to the hwdata package.