### PR TITLE
Add nvme-cli package

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -88,6 +88,7 @@ lsscsi:
 mdadm:
 net-tools:
 ?net-tools-deprecated:
+nvme-cli:
 sed:
 ?wicked:
 ?s390-tools-hmcdrvfs:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -132,6 +132,7 @@ net-tools:
 netcat-openbsd:
 nscd:
 ntfsprogs:
+nvme-cli:
 open-iscsi:
 ?fcoe-utils:
 openslp:


### PR DESCRIPTION
## Problem

Package `nvme-cli` needs to be available during installation.

* https://bugzilla.suse.com/show_bug.cgi?id=1127815
* https://trello.com/c/XkYulGSK/790-pls-add-nvme-cli-to-inst-images-bsc-1127815

## Solution

* Package `nmve-cli` is added to `initrd` and `rescue` images.
* Package `nmve-cli` is added as build dependency to `installation-images.spec` in `system:install:head`: https://build.opensuse.org/request/show/682146
