### PR TITLE
adjust EFI boot setup to also include RPi firmware files (jsc:SLE-4394)

### DIFF
--- a/install.aarch64
+++ b/install.aarch64
@@ -22,8 +22,7 @@ for theme in $THEMES ; do
   done
 
   if [ -d images/$theme/EFI ] ; then
-    mkdir -p $DESTDIR/branding/$theme/CD1/EFI/BOOT
-    cp -r images/$theme/EFI/EFI/BOOT/* $DESTDIR/branding/$theme/CD1/EFI/BOOT
+    cp -r images/$theme/EFI/* $DESTDIR/branding/$theme/CD1
   fi
 done
 

--- a/install.i386
+++ b/install.i386
@@ -35,8 +35,7 @@ for theme in $THEMES ; do
   done
 
   if [ -d images/$theme/EFI ] ; then
-    mkdir -p $DESTDIR/branding/$theme/CD1/EFI/BOOT
-    cp -r images/$theme/EFI/EFI/BOOT/* $DESTDIR/branding/$theme/CD1/EFI/BOOT
+    cp -r images/$theme/EFI/* $DESTDIR/branding/$theme/CD1
   fi
 
   # xen initrd


### PR DESCRIPTION
The firmware files are in the root dir of the EFI partition. Apply the same
code simplification also to x86.