### PR TITLE
Package mkfontdir is optional. So it can be obsoleted by package mkfo…

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -79,7 +79,7 @@ insserv-compat:
 kbd:
 krb5:
 make:
-mkfontdir:
+?mkfontdir:
 mkfontscale:
 kmod-compat:
 openslp:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -474,7 +474,7 @@ if arch ne 's390' && arch ne 's390x'
 endif
 
 mkfontscale:
-mkfontdir:
+?mkfontdir:
 setxkbmap:
 xdpyinfo:
 xhost:


### PR DESCRIPTION
…ntscale.