### PR TITLE
fine-tune RPi firmware inclusion (jsc:SLE-4394)

### DIFF
--- a/install.aarch64
+++ b/install.aarch64
@@ -22,7 +22,7 @@ for theme in $THEMES ; do
   done
 
   if [ -d images/$theme/EFI ] ; then
-    cp -r images/$theme/EFI/* $DESTDIR/branding/$theme/CD1
+    cp -r images/$theme/EFI/EFI $DESTDIR/branding/$theme/CD1
   fi
 done
 

--- a/install.i386
+++ b/install.i386
@@ -35,7 +35,7 @@ for theme in $THEMES ; do
   done
 
   if [ -d images/$theme/EFI ] ; then
-    cp -r images/$theme/EFI/* $DESTDIR/branding/$theme/CD1
+    cp -r images/$theme/EFI/EFI $DESTDIR/branding/$theme/CD1
   fi
 
   # xen initrd


### PR DESCRIPTION
After checking how the product builder works it should be enough if the
firmware files are put into the EFI *image* (in boot/ARCH/efi).

This will remove the firmware files from the root dir of the DVD but keep
them on the EFI system partition.