### PR TITLE
Establish MicroOS as seperate media

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -128,9 +128,19 @@ systemd     = CAASP
 
 [Theme Kubic]
 image       = 350
-release     = openSUSE-Tumbleweed-Kubic
+release     = openSUSE-MicroOS
 skelcd      = openSUSE
 skelcd_ctrl = Kubic
+gfxboot     = openSUSE
+grub2       = openSUSE
+plymouth    = openSUSE
+systemd     = MicroOS
+
+[Theme MicroOS]
+image       = 350
+release     = openSUSE-MicroOS
+skelcd      = openSUSE
+skelcd_ctrl = MicroOS
 gfxboot     = openSUSE
 grub2       = openSUSE
 plymouth    = openSUSE

--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -70,7 +70,7 @@ ID="opensuse-tumbleweed-kubic"
 ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:opensuse-tumbleweed-kubic:20170905"
 
-== openSUSE Tumbleweed Kubic ==
+== openSUSE Tumbleweed Kubic [obsolete] ==
 
 NAME="openSUSE Tumbleweed Kubic"
 # VERSION="20170909"
@@ -82,6 +82,20 @@ ANSI_COLOR="0;32"
 CPE_NAME="cpe:/o:opensuse:tumbleweed-kubic:20170909"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
+
+== openSUSE MicroOS ==
+
+NAME="openSUSE MicroOS"
+# VERSION="20190301"
+ID="opensuse-microos"
+ID_LIKE="suse opensuse opensuse-tumbleweed"
+VERSION_ID="20190301"
+PRETTY_NAME="openSUSE MicroOS"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:microos:20190301"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
+
 
 == sles12 ==
 

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -925,9 +925,9 @@ sub get_version_info
 
   # don't accept other names than these
 
-  die "*** unsupported product: $dist ***" if $dist !~ /^(casp|caasp|kubic|leap|sles|sled|tumbleweed( kubic)?)$/;
+  die "*** unsupported product: $dist ***" if $dist !~ /^(casp|caasp|kubic|microos|leap|sles|sled|tumbleweed( kubic)?)$/;
 
-  my $is_tw = $dist =~ /^tumbleweed( kubic)?$/;
+  my $is_tw = $dist =~ /^(microos|tumbleweed( kubic)?)$/;
 
   # kubic uses 'tw' as dist tag
   $dist = $is_tw ? 'tw' : "$dist$config{VERSION_ID}";


### PR DESCRIPTION
MicroOS is now going to be a standalone distribution for single-service installations, with Kubic being a derivative of MicroOS focused on containers and kubernetes

This requires different products, installation media, etc.. so, here's the installation-images changes required