### PR TITLE
add more aarch64 modules (bsc #1129815)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -122,6 +122,7 @@ xen-balloon,-,-
 xen-platform-pci,-,-
 xenbus,-,-
 lis3lv02d,-,-
+bcm2835-dma
 bcma
 caif_hsi
 ptp
@@ -132,6 +133,7 @@ ptp_qoriq
 pps_core
 gpio-cs5535
 gpio-thunderx
+gpio-raspberrypi-exp
 libore
 virtio_pci,-,-,,virtio_blk virtio_net virtio_balloon 
 ac97_bus

--- a/etc/module.list
+++ b/etc/module.list
@@ -199,6 +199,7 @@ kernel/drivers/misc/lis3lv02d/lis3lv02d.ko
 kernel/drivers/misc/cs5535-mfgpt.ko
 kernel/drivers/gpio/gpio-cs5535.ko
 kernel/drivers/gpio/gpio-thunderx.ko
+kernel/drivers/gpio/gpio-raspberrypi-exp.ko
 kernel/drivers/ptp/
 kernel/drivers/pps/pps_core.ko
 kernel/drivers/usb/class/cdc-wdm.ko
@@ -247,6 +248,8 @@ kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
 
 kernel/fs/efivarfs/
+
+kernel/drivers/dma/bcm2835-dma.ko
 
 # kmps
 updates/


### PR DESCRIPTION
Needed are:
  bcm2835-dma.ko
  gpio-raspberrypi-exp.ko