### PR TITLE
patch zypp config also for MicroOS (bsc #1132848)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -120,7 +120,7 @@ linuxrc:
 # add zypp config to initrd to ensure it's writable
 libzypp: nodeps
   /etc
-  if (theme eq 'CAASP') || (theme eq 'Kubic')
+  if patch_zypp_config_theme
     # patch /etc/zypp/zypp.conf (fate #321764); sets
     # solver.onlyRequires = true, rpm.install.excludedocs = yes, multiversion =
     R s/^[#[:space:]]*(solver.onlyRequires)\s+=.*/# minimal CAASP\n$1 = true/ etc/zypp/zypp.conf

--- a/doc/branding.md
+++ b/doc/branding.md
@@ -5,15 +5,16 @@ To add a new theme, add a new `Theme` section to etc/config. Example for theme
 
 ```sh
 [Theme SLES]
-image       = 600			# memory limit for loading inst-sys: 600 MB
+image             = 600		# memory limit for loading inst-sys: 600 MB
+patch_zypp_config = 0		# whether to adjust zypp.conf for micro-os-like systems
 # other entries are branding prefixes or suffixes to branding-related packages
-release     = sles			# sles-release.rpm
-skelcd      = sles			# skelcd-sles.rpm
-skelcd_ctrl = SLES			# skelcd-control-SLES.rpm
-gfxboot     = SLE			# gfxboot-branding-SLE.rpm
-grub2       = SLE			# grub2-branding-SLE.rpm
-plymouth    = SLE			# plymouth-branding-SLE.rpm
-systemd     = SLE			# systemd-presets-branding-SLE.rpm
+release           = sles	# sles-release.rpm
+skelcd            = sles	# skelcd-sles.rpm
+skelcd_ctrl       = SLES	# skelcd-control-SLES.rpm
+gfxboot           = SLE		# gfxboot-branding-SLE.rpm
+grub2             = SLE		# grub2-branding-SLE.rpm
+plymouth          = SLE		# plymouth-branding-SLE.rpm
+systemd           = SLE		# systemd-presets-branding-SLE.rpm
 ```
 
 Then add an appropriate theme section to `installation-images.spec`.

--- a/etc/config
+++ b/etc/config
@@ -67,7 +67,8 @@ floppy	=
 
 ; Define per-theme related values.
 ;
-; 'image' ends up as MemLoadImage entry in linuxrc.config.
+; 'image': MemLoadImage entry in linuxrc.config
+; 'patch_zypp_config': whether to adjust zypp.conf for micro-os & co
 ;
 ; All other values are intended as suffixes for branding packages. Values
 ; can be used as <foo_theme> in *.file_list files.
@@ -77,81 +78,89 @@ floppy	=
 ; You can override settings via env vars of the same name ('foo_theme').
 ;
 [Theme openSUSE]
-image	    = 350
-release     = openSUSE
-skelcd      = openSUSE
-skelcd_ctrl = openSUSE
-gfxboot     = openSUSE
-grub2       = openSUSE
-plymouth    = openSUSE
-systemd     = openSUSE
+image             = 350
+patch_zypp_config = 0
+release           = openSUSE
+skelcd            = openSUSE
+skelcd_ctrl       = openSUSE
+gfxboot           = openSUSE
+grub2             = openSUSE
+plymouth          = openSUSE
+systemd           = openSUSE
 
 [Theme SLES]
-image	    = 600
-release     = unified-installer
-skelcd      = sles
-skelcd_ctrl = leanos
-gfxboot     = SLE
-grub2       = SLE
-plymouth    = SLE
-systemd     = SLE
+image             = 600
+patch_zypp_config = 0
+release           = unified-installer
+skelcd            = sles
+skelcd_ctrl       = leanos
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = SLE
 
 [Theme SLES_SAP]
-image       = 600
-release     = unified-installer
-skelcd      = sles
-skelcd_ctrl = leanos
-gfxboot     = SLE
-grub2       = SLE
-plymouth    = SLE
-systemd     = SLE
+image             = 600
+patch_zypp_config = 0
+release           = unified-installer
+skelcd            = sles
+skelcd_ctrl       = leanos
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = SLE
 
 [Theme SLED]
-image	    = 600
-release     = unified-installer
-skelcd      = sled
-skelcd_ctrl = leanos
-gfxboot     = SLE
-grub2       = SLE
-plymouth    = SLE
-systemd     = SLE
+image             = 600
+patch_zypp_config = 0
+release           = unified-installer
+skelcd            = sled
+skelcd_ctrl       = leanos
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = SLE
 
 [Theme CAASP]
-image	    = 600
-release     = caasp
-skelcd      = caasp
-skelcd_ctrl = CAASP
-gfxboot     = SLE
-grub2       = SLE
-plymouth    = SLE
-systemd     = CAASP
+image             = 600
+patch_zypp_config = 1
+release           = caasp
+skelcd            = caasp
+skelcd_ctrl       = CAASP
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = CAASP
 
 [Theme Kubic]
-image       = 350
-release     = openSUSE-MicroOS
-skelcd      = openSUSE
-skelcd_ctrl = Kubic
-gfxboot     = openSUSE
-grub2       = openSUSE
-plymouth    = openSUSE
-systemd     = MicroOS
+image             = 350
+patch_zypp_config = 1
+release           = openSUSE-MicroOS
+skelcd            = openSUSE
+skelcd_ctrl       = Kubic
+gfxboot           = openSUSE
+grub2             = openSUSE
+plymouth          = openSUSE
+systemd           = MicroOS
 
 [Theme MicroOS]
-image       = 350
-release     = openSUSE-MicroOS
-skelcd      = openSUSE
-skelcd_ctrl = MicroOS
-gfxboot     = openSUSE
-grub2       = openSUSE
-plymouth    = openSUSE
-systemd     = MicroOS
+image             = 350
+patch_zypp_config = 1
+release           = openSUSE-MicroOS
+skelcd            = openSUSE
+skelcd_ctrl       = MicroOS
+gfxboot           = openSUSE
+grub2             = openSUSE
+plymouth          = openSUSE
+systemd           = MicroOS
 
 [Theme Zen]
-image       = 600
-release     = unified-installer
-skelcd      = sles
-skelcd_ctrl = leanos
-gfxboot     = SLE
-grub2       = SLE
-plymouth    = SLE
-systemd     = SLE
+image             = 600
+patch_zypp_config = 0
+release           = unified-installer
+skelcd            = sles
+skelcd_ctrl       = leanos
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = SLE


### PR DESCRIPTION
`MicroOS` also needs the adjusted zypp config.

The patch introduces a new per-theme `patch_zypp_config` config setting that can be referenced as `patch_zypp_config_theme` in the file lists.

The rest are whitespace changes.