### PR TITLE
add /dev/btrfs-control to initrd (bsc#1133368)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -24,6 +24,9 @@ C 4 9 /dev/tty9
 c 660 0 5 /dev/tty9
 C 5 1 /dev/console
 c 600 0 5 /dev/console
+# btrfs-control is also needed (bsc#1133368)
+C 10 234 /dev/btrfs-control
+c 660 0 0 /dev/btrfs-control
 b 7 0 /dev/loop0
 c 660 0 6 /dev/loop0
 b 7 1 /dev/loop1


### PR DESCRIPTION
Looks like `/dev/btrfs-control` is one of those devices that have to pre-exist.