### PR TITLE
add udev rule to prevent raid auto-assembly (bsc#1132688)

### DIFF
--- a/data/initrd/etc/00-inhibit.rules
+++ b/data/initrd/etc/00-inhibit.rules
@@ -1,0 +1,1 @@
+ENV{ANACONDA}="yes"

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -642,6 +642,9 @@ x etc/adjtime etc
 x etc/bashrc /.profile
 x etc/bashrc root/.profile
 
+# prevent raid auto-assembly (bsc#1132688)
+x etc/00-inhibit.rules /etc/udev/rules.d
+
 e ldconfig -r .
 
 # get the gpg keys to trust from build root


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1132688
- https://trello.com/c/0S3qkpcj