### PR TITLE
Revert "add /dev/btrfs-control to initrd (bsc#1133368)"

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -24,9 +24,6 @@ C 4 9 /dev/tty9
 c 660 0 5 /dev/tty9
 C 5 1 /dev/console
 c 600 0 5 /dev/console
-# btrfs-control is also needed (bsc#1133368)
-C 10 234 /dev/btrfs-control
-c 660 0 0 /dev/btrfs-control
 b 7 0 /dev/loop0
 c 660 0 6 /dev/loop0
 b 7 1 /dev/loop1

--- a/etc/module.config
+++ b/etc/module.config
@@ -259,7 +259,8 @@ snd_seq
 snd_pcm_oss
 8021q
 dm-multipath
-
+# btrfs needs to be loaded to get /dev/btrfs-control (bsc#1133368)
+btrfs
 
 [IDE/RAID/SCSI]
 MoreModules=scsi-modules


### PR DESCRIPTION
This reverts commit 753eade4a36683a949e0844037516eace80f5bde.

The original approach does not work as `/dev` is entirely handled by devtmpfs and the original device nodes in the image do not survive the instsys startup.
Loading the module triggers the creation of `/dev/btrfs-control` and btrfs is our default file system anyway.