### PR TITLE
follow aaa_base package change

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -122,6 +122,7 @@ aaa_base:
   E prein
   E postin
   t etc/fstab
+  /etc
   /sbin/service
   /usr/sbin/service
 


### PR DESCRIPTION
`/etc/sysctl.conf` used to be created in post-in; now it's directly included.