### PR TITLE
aarch64: ptp_qoriq.ko is now ptp-qoriq.ko

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -130,6 +130,7 @@ ptp_kvm
 ptp_pch
 ptp_dte
 ptp_qoriq
+ptp-qoriq
 pps_core
 gpio-cs5535
 gpio-thunderx


### PR DESCRIPTION
The `ptp_qoriq.ko` kernel module has been renamed in Factory. Keep also the old name so we continue to work in SLES.