### PR TITLE
set root password for rescue system explicitly (bsc#1134524)

### DIFF
--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -46,10 +46,10 @@ if [ -e /usr/lib/systemd/system/sshd.service -a "$SSH" = 1 ] ; then
   ln -s ../sshd.service /etc/systemd/system/multi-user.target.wants
 fi
 
-if [ -n "$SSHPASSWORDENC" ] ; then
-  echo "root:$SSHPASSWORDENC" | chpasswd -e
-elif [ -n "$SSHPASSWORD" ] ; then
+if [ -n "$SSHPASSWORD" ] ; then
   echo "root:$SSHPASSWORD" | chpasswd
+else
+  echo "root:$SSHPASSWORDENC" | chpasswd -e
 fi
 
 # keep some initrd config files for rescue system


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1134524#c14

rescue system login no longer works.

### Solution

root login is per default disabled. So a password must be set in any case even if it's an empty one.