### PR TITLE
update udevd startup script (bsc#1135909)

### DIFF
--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -16,8 +16,9 @@ echo "" > /proc/sys/kernel/hotplug
 echo -n "Starting udevd "
 udevd --daemon
 
-# create devices
-/usr/bin/udevadm trigger
+# create devices (cf. bsc#1084357)
+/usr/bin/udevadm trigger --type=subsystems --action=add
+/usr/bin/udevadm trigger --type=devices --action=add
 
 # 10 min - just long enough
 /usr/bin/udevadm settle --timeout=100

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -14,7 +14,11 @@ echo "" > /proc/sys/kernel/hotplug
 
 # start udevd
 echo -n "Starting udevd "
-udevd --daemon
+if [ -n "$linuxrc_debug" ] ; then
+  udevd --daemon --debug 2>/var/log/udev.log
+else
+  udevd --daemon
+fi
 
 # create devices (cf. bsc#1084357)
 /usr/bin/udevadm trigger --type=subsystems --action=add


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1135909

udevd doesn't load all modules on startup.

### Solution

This issue had already been fixed in `master` (https://github.com/openSUSE/installation-images/pull/235).
And while we're at it, allow udevd debug logging (also from `master`, https://github.com/openSUSE/installation-images/pull/238).