### PR TITLE
add ptp_qoriq to module config

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -129,6 +129,7 @@ caif_hsi
 ptp
 ptp_kvm
 ptp_pch
+ptp_qoriq
 pps_core
 gpio-cs5535
 gpio-thunderx


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1137243

Kernel module list has changed.

### Solution

Add missing `ptp_qoriq` module.