### PR TITLE
Rename product_short to be Kubic relevant

### DIFF
--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -1327,6 +1327,11 @@ $ConfigData{fw_list} = $ConfigData{ini}{Firmware}{$arch} if $ConfigData{ini}{Fir
     $ConfigData{$_ . '_theme'} = $ConfigData{ini}{"Theme $theme"}{$_};
   }
 
+  # if $ConfigData{os}{product_short} is "openSUSE MicroOS" and $theme is "Kubic" then make $ConfigData{os}{product_short} actually equal "openSUSE Kubic"
+  if (($ConfigData{os}{product_short} =~ /openSUSE MicroOS/) && ($theme =~ /Kubic/)) {
+     $ConfigData{os}{product_short} = "openSUSE Kubic"
+  }
+
   $ConfigData{product_name} = $ConfigData{os}{product_mini} || "openSUSE";
   ($ConfigData{product_name_nospaces} = $ConfigData{product_name}) =~ s/\s+/-/g;
   ($ConfigData{product_short} = $ConfigData{os}{product_short} || "SUSE") =~ s/\s+/-/g;


### PR DESCRIPTION
To basically complete what https://build.opensuse.org/package/rdiff/system:install:head/installation-images?linkrev=base&rev=1230 set out to achieve, this patch should stop the files for Kubic being created in /usr/share/tftpboot-installation/openSUSE-MicroOS-x86_64 and instead be created in /usr/share/tftpboot-installation/openSUSE-Kubic-x86_64