### PR TITLE
remove SuSEfirewall2 dependency that was introduced in bnc#887406

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -306,12 +306,6 @@ yast2-installation:
   # hack to make 'repair' option work
   # p repair.diff
 
-# bnc#887406 SuSEfirewall2 configuration needed for AutoYast export
-# both in installation proposal and at the end of installation
-SuSEfirewall2:
-  d /etc/sysconfig/SuSEfirewall2.d/services/
-  /etc/sysconfig/SuSEfirewall2
-
 if arch eq 'ppc' || arch eq 'ppc64'
   pdisk:
     /sbin/pdisk


### PR DESCRIPTION
### Problem

installation-images still relies on SuSEfirewall2, even though this package is no longer used. The dependency was added in [bsc\#887406](https://bugzilla.suse.com/show_bug.cgi?id=887406) due to some AutoYaST requirement that needed the config files of SuSEfirewall2.

### Solution

Do no longer use SuSEfirewall2. The package does not exist anymore and yast can't possibly still rely on it.