### PR TITLE
add vmd.ko module (bsc#1139973)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -191,6 +191,7 @@ kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/md/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*
+kernel/drivers/pci/host/.*
 kernel/drivers/platform/.*
 kernel/drivers/regulator/.*
 kernel/drivers/base/regmap/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -247,6 +247,7 @@ kernel/drivers/usb/dwc2/
 kernel/drivers/usb/dwc3/
 kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/regulator/
+kernel/drivers/pci/host/
 
 kernel/fs/efivarfs/
 


### PR DESCRIPTION
### Problem

Module `vmd.ko` is missing.

### Bugzilla

[bsc\#1139973](https://bugzilla.suse.com/show_bug.cgi?id=1139973)

### Solution

Backport [bsc\#1079924](https://bugzilla.suse.com/show_bug.cgi?id=1079924) to sle12-sp3 branch.

### References

Original fix in `master`: https://github.com/openSUSE/installation-images/pull/234