### PR TITLE
aarch64: fix kernel and initrd location in grub config (bsc#1141038)

### DIFF
--- a/data/boot/grub-aarch64.cfg
+++ b/data/boot/grub-aarch64.cfg
@@ -68,9 +68,9 @@ submenu 'More ...' {
   menuentry 'Boot Linux System' --class opensuse --class gnu-linux --class gnu {
     set gfxpayload=keep
     echo 'Loading kernel ...'
-    linux /boot/aarch64/loader/linux splash=silent systemboot=1
+    linux /boot/aarch64/linux splash=silent systemboot=1
     echo 'Loading initial ramdisk ...'
-    initrd /boot/aarch64/loader/initrd
+    initrd /boot/aarch64/initrd
   }
 
   menuentry 'Check Installation Media' --class opensuse --class gnu-linux --class gnu {


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1141038

"Boot Linux System" menu entry on aarch64 does not work. It loads kernel/initrd from
the wrong location.

### Solution

Fix kernel/initrd path.