### PR TITLE
Backport:  add 'autoassembly' boot option to prevent MD/RAID autoassembly (bsc #1132688)

### DIFF
--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -12,6 +12,13 @@ done
 # disable hotplug helper, udevd listens to netlink
 echo "" > /proc/sys/kernel/hotplug
 
+# prevent MD/RAID auto-assembly (bsc#1132688)
+# Note: rules in /run are not copied to the target system, unlike those in /etc.
+if [ -n "$linuxrc_no_auto_assembly" ] ; then
+  mkdir -p /run/udev/rules.d
+  echo 'ENV{ANACONDA}="yes"' > /run/udev/rules.d/00-inhibit.rules
+fi
+
 # start udevd
 echo -n "Starting udevd "
 if [ -n "$linuxrc_debug" ] ; then


### PR DESCRIPTION
_This is a backport of PR #311_

## Trello

https://trello.com/c/A1orfA6C/1135-2-sle12-sp5-p2-1138583-error-disk-remove-partition-failed-occurred-while-installing-on-multipath-setup

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1138583

## Original PR

https://github.com/openSUSE/installation-images/pull/311

Cherry-picked the one commit from that PR. There were no conflicts.