### PR TITLE
allow explicit setting of product name

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -142,6 +142,7 @@ gfxboot           = openSUSE
 grub2             = openSUSE
 plymouth          = openSUSE
 systemd           = MicroOS
+product_name      = openSUSE-Kubic
 
 [Theme MicroOS]
 image             = 350

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -1329,7 +1329,7 @@ $ConfigData{fw_list} = $ConfigData{ini}{Firmware}{$arch} if $ConfigData{ini}{Fir
 
   $ConfigData{product_name} = $ConfigData{os}{product_mini} || "openSUSE";
   ($ConfigData{product_name_nospaces} = $ConfigData{product_name}) =~ s/\s+/-/g;
-  ($ConfigData{product_short} = $ConfigData{os}{product_short} || "SUSE") =~ s/\s+/-/g;
+  ($ConfigData{product_short} = $ConfigData{product_name_theme} || $ConfigData{os}{product_short} || "SUSE") =~ s/\s+/-/g;
   $ConfigData{update_dir} = $ConfigData{os}{update};
   $ConfigData{load_image} = $load_image;
 


### PR DESCRIPTION
### Problem

openSUSE-Kubic is based on MicroOS and all the config files say so. But still it should show up as 'Kubic'.

### Solution

Allow to set the product name explicitly per theme in `etc/config`.

### Note

A similar override exists in `installation-images.spec`.