### PR TITLE
xorg.conf.template: disable acceleration for modeset driver

### DIFF
--- a/data/root/etc/xorg.conf.template
+++ b/data/root/etc/xorg.conf.template
@@ -24,6 +24,7 @@ Section "Device"
   Identifier "modesetting"
   Driver  "modesetting"
   Option "PreferCloneMode" "true"
+  Option "AccelMethod" "none"
 EndSection
 Section "Screen"
   Identifier "modesetting"

--- a/data/root/etc/xorg.conf.template
+++ b/data/root/etc/xorg.conf.template
@@ -23,6 +23,7 @@ EndSection
 Section "Device"
   Identifier "modesetting"
   Driver  "modesetting"
+  Option "PreferCloneMode" "true"
 EndSection
 Section "Screen"
   Identifier "modesetting"


### PR DESCRIPTION
data/root/etc/xorg.conf.template: disable acceleration for modeset driver
    
Added  Option "AccelMethod" "none" for modeset driver. No longer let
glamor initialization fail if no appropriate OpenGL driver is available.
(boo#1141947)
