### PR TITLE
add all gpio modules (bsc #1145777)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -132,9 +132,6 @@ ptp_dte
 ptp_qoriq
 ptp-qoriq
 pps_core
-gpio-cs5535
-gpio-thunderx
-gpio-raspberrypi-exp
 libore
 virtio_pci,-,-,,virtio_blk virtio_net virtio_balloon 
 ac97_bus
@@ -183,6 +180,7 @@ kernel/crypto/.*
 kernel/drivers/crypto/.*
 kernel/drivers/.*/crypto/.*
 kernel/drivers/firmware/.*
+kernel/drivers/gpio/.*
 kernel/drivers/i2c/.*
 kernel/drivers/input/.*
 kernel/drivers/leds/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -197,9 +197,7 @@ kernel/drivers/video/fbdev/hyperv_fb.ko
 
 kernel/drivers/misc/lis3lv02d/lis3lv02d.ko
 kernel/drivers/misc/cs5535-mfgpt.ko
-kernel/drivers/gpio/gpio-cs5535.ko
-kernel/drivers/gpio/gpio-thunderx.ko
-kernel/drivers/gpio/gpio-raspberrypi-exp.ko
+kernel/drivers/gpio/
 kernel/drivers/ptp/
 kernel/drivers/pps/pps_core.ko
 kernel/drivers/usb/class/cdc-wdm.ko


### PR DESCRIPTION
### Problem

https://bugzilla.suse.com/show_bug.cgi?id=1145777

Individual requests to add certain gpio modules when new hardware needs to be supported.

### Solution

Add them all. They add up to about 100 kB compressed. Not that much.