### PR TITLE
handle compressed modules

### DIFF
--- a/bin/kernel_mods
+++ b/bin/kernel_mods
@@ -10,7 +10,7 @@ for $rpm (@ARGV) {
   $archs{$arch} = 1;
 
   for (@files) {
-    if(m#^/lib/modules/.*/([^/]+).ko#) {
+    if(m#^/lib/modules/.*/([^/]+)\.ko#) {
       $mod->{$1}{$arch} = 1;
     }
   }

--- a/bin/mlist2
+++ b/bin/mlist2
@@ -155,7 +155,7 @@ for (@cfg_file) {
     $l0 = $l[0];
     for $m1 (@fname_list) {
       $l[0] = $m1;
-      if($fname{$l[0]} =~ m#^$l0$#) {
+      if($fname{$l[0]} =~ m#^$l0(?:\.xz)?$#) {
         # print "$l0 - $fname{$l[0]} - $l[0]\n";
 
         $all{$l[0]} = 1;

--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -8,13 +8,13 @@ $fw_dir = shift;
 
 $err = 0;
 
-for $m (<$modules_dir/*.ko>) {
+for $m (<$modules_dir/*.ko{,.xz}>) {
   chomp $m;
 
   chomp(@l = `modinfo -F firmware $m`);
 
   $m =~ s#.*/##;
-  $m =~ s#.ko$##;
+  $m =~ s#\.ko(?:\.xz)?$##;
 
   $fw{$m} = [ @l ] if @l;
 }

--- a/data/initrd/modules-config.file_list
+++ b/data/initrd/modules-config.file_list
@@ -5,6 +5,6 @@
   L boot/System.map* System.map
   e /sbin/depmod -a -b . -F System.map <kernel_ver>
   e cp lib/modules/<kernel_ver>/modules.dep .
-  e find lib/modules/<kernel_ver> -name *.ko | xargs modinfo >modules.info
+  e find lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' | xargs modinfo >modules.info
   r System.map lib
 

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -6,7 +6,7 @@ PATH="/sbin:/bin:/usr/bin:/usr/sbin:/lbin"
 
 # load some modules before udevd
 for i in edd scsi_dh_alua scsi_dh_emc scsi_dh_rdac ; do
-  [ -f /modules/$i.ko ] && modprobe $i
+  [ -f /modules/$i.ko -o -f /modules/$i.ko.xz ] && modprobe $i
 done
 
 # disable hotplug helper, udevd listens to netlink

--- a/gefrickel
+++ b/gefrickel
@@ -39,7 +39,9 @@ m_dir=`echo lib/modules/*/initrd`
 [ -d "$m_dir" ] || err "no kernel module dir"
 mkdir -p "b/$m_dir"
 for i in loop squashfs lz4_decompress xxhash zstd_decompress; do
-  [ -f $m_dir/$i.ko ] && mv $m_dir/$i.ko b/$m_dir
+  for suffix in ko ko.xz; do
+    [ -f $m_dir/$i.$suffix ] && mv $m_dir/$i.$suffix b/$m_dir
+  done
 done
 mkdir -p a/lib
 mv lib/modules a/lib

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -1299,7 +1299,14 @@ $ConfigData{fw_list} = $ConfigData{ini}{Firmware}{$arch} if $ConfigData{ini}{Fir
 
     $ConfigData{kernel_img} = $k_images[0];
     $ConfigData{kernel_ver} = ReadFile "$k_dir/kernel";
-    $ConfigData{module_type} = 'ko';
+
+    my $mod_type = `find $k_dir/rpm/lib/modules/*/kernel/ -type f -name '*.ko*' -print -quit`;
+    if (!$mod_type) {
+      die "Error: No kernel module found! (Looking for '*.ko*' in '$k_dir/rpm/lib/modules/*/kernel/')\n\n";
+    }
+    chomp $mod_type;
+    $mod_type =~ /\.(ko(?:\.xz)?)$/;
+    $ConfigData{module_type} = $1;
   }
 
   # print STDERR "kernel_img = $ConfigData{kernel_img}\n";


### PR DESCRIPTION
Modules have .ko.xz suffix since kernel 5.3. Handle that in the scripts.

While at it, make sure that the dot in .ko is escaped properly on places
where .ko is used.