### PR TITLE
fix sshd location so that it works with fips enabled (bsc#1140169)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -425,9 +425,6 @@ dbus-1:
 
 libopenssl*_*_*-hmac:
 
-?openssh-fips:
-?openssh-hmac:
-
 openssh: nodeps
   E prein
   d etc/ssh

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -321,6 +321,8 @@ mdadm:
 multipath-tools:
 nfs-client:
 
+?openssh-fips:
+
 openssh:
   /
   d /etc/sysconfig

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -601,6 +601,8 @@ if !exists(yast2-storage-ng)
     E postin
 endif
 
+?openssh-fips:
+
 openssh:
   /
   t /etc/sysconfig/ssh


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1140169

sshd does not work in installation system when fips is enabled.

## Solution

The hmac has to be really at the same location as the binary. Symlinking
around is no good.