### PR TITLE
add nvme-cli (bsc #1150951)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -87,6 +87,7 @@ mdadm:
 net-tools:
 ?net-tools-deprecated:
 nfsidmap:
+nvme-cli:
 sed:
 ?wicked:
 ?s390-tools-hmcdrvfs:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -135,6 +135,7 @@ netcat-openbsd:
 nfsidmap:
 nscd:
 ntfsprogs:
+nvme-cli:
 open-iscsi:
 ?fcoe-utils:
 openslp:


### PR DESCRIPTION
## Task

https://bugzilla.suse.com/show_bug.cgi?id=1150951
https://trello.com/c/jeVFmWC4/1316-sle12-sp5-add-nvme-cli-to-inst-sys

Include `nvme-cli` package.

## See also

Same had been done for `master` branch: https://github.com/openSUSE/installation-images/pull/297