### PR TITLE
do not stop haveged process in inst_setup (bsc#1140171)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -248,7 +248,6 @@ nscd --shutdown
 killall slpd >/dev/null 2>&1
 killall Xvnc >/dev/null 2>&1
 killall sshd >/dev/null 2>&1
-killall haveged >/dev/null 2>&1
 
 umount /usr/bin/gdb 2>/dev/null
 umount devpts 2>/dev/null


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1140171

At the end of the installation, some processes might lock up when fips is enabled.

## Solution

Do not kill haveged.

The process is handled (started) by linuxrc.

## See also

- same in sle12-sp3 branch: https://github.com/openSUSE/installation-images/pull/333
- related change in yast: https://github.com/yast/yast-installation/pull/818
- Scrum card: https://trello.com/c/PiMSEWGo