### PR TITLE
add /etc/zkey to initrd to ensure it is writable (jsc#SLE-7376)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -164,6 +164,7 @@ suse-module-tools:
   /sbin/dasdinfo
   /sbin/chzdev
   /etc/udev
+  /etc/zkey
   /boot
 
 kbd:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -163,7 +163,7 @@ suse-module-tools:
   /sbin/qeth_configure
   /sbin/dasdinfo
   /sbin/chzdev
-  /etc/udev
+  /usr/lib/udev
   /etc/zkey
   /boot
 


### PR DESCRIPTION
## Task

https://trello.com/c/HKaDMPL6/1297-5-pervasive-encryption-partitioner

Ensure `/etc/ykey` is writable during installation.

## Solution

Add the directory to initrd.

## Bonus

While doing this, I noticed the code still includes `/etc/udev` from s390-tools. But the default udev rules have been moved to `/usr/lib/udev` meanwhile. I hope this will do more good than harm.