### PR TITLE
ensure /etc/sysctl.d is writable

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -391,6 +391,8 @@ systemd:
   /usr/lib/systemd/*.so
   # plymouth is not working if we include all rules - no idea why
   /usr/lib/udev/rules.d/99-systemd.rules
+  # needed to ensure it's writable
+  /etc/sysctl.d
 
 sysconfig:
   /


### PR DESCRIPTION
## Problem

`/etc/sysctl.d` is not writable in installation system.

## Solution

Ensure directory is created in initrd.