### PR TITLE
adjust samba library list

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -329,7 +329,7 @@ nscd:
   d /var/run/nscd
 
 ?virtualbox-guest-tools: nodeps
-  /etc/udev
+  /usr/lib/udev/rules.d
 
 ?xf86-input-vmmouse: nodeps
   /usr/lib/udev/rules.d

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -339,6 +339,7 @@ nscd:
 
 shadow:
   /etc
+  /usr/etc
   /usr/sbin/groupadd
   /usr/sbin/useradd
   /usr/sbin/useradd.local
@@ -347,6 +348,7 @@ shadow:
 pam:
   /sbin
   /etc
+  /usr/etc
   /lib*/libpam*.so.*
   /lib*/security/pam_group.so
   /lib*/security/pam_unix*.so

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -55,19 +55,6 @@ update-alternatives: ignore
 ?mkinitrd: ignore
 perl: ignore
 filesystem: ignore
-
-if exists(samba-client-libs)
-  samba-client-libs: nodeps
-    /usr/lib*/samba/libreplace*.so
-
-  samba-libs: nodeps
-    /usr/lib*/samba/libwinbind-client*.so
-else
-  samba-libs: nodeps
-    /usr/lib*/samba/libreplace*.so
-    /usr/lib*/samba/libwinbind-client*.so
-endif
-
 ?biosdevname:
 ?bcm43xx-firmware: nodeps
 bcache-tools:
@@ -127,6 +114,9 @@ libzypp: nodeps
     R s/^[#[:space:]]*(rpm.install.excludedocs)\s+=.*/# minimal CAASP\n$1 = yes/ etc/zypp/zypp.conf
     R s/^[#[:space:]]*(multiversion)\s+=.*/# minimal CAASP\n$1 =/ etc/zypp/zypp.conf
   endif
+
+samba-libs: nodeps
+  /usr/lib*/samba/lib{replace,winbind-client,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
 
 diffutils:
   /usr/bin/cmp

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -337,9 +337,6 @@ nscd:
 ?xf86-input-wacom: nodeps
   /usr/lib/udev/rules.d
 
-multipath-tools:
-  /var/cache/multipath
-
 shadow:
   /etc
   /usr/sbin/groupadd

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -178,17 +178,8 @@ vim:
 
 # we have full samba in rescue-server
 if filelist ne 'rescue-server'
-  if exists(samba-client-libs)
-    samba-client-libs: nodeps
-      /usr/lib*/samba/libreplace*.so
-
-    samba-libs: nodeps
-      /usr/lib*/samba/libwinbind-client*.so
-  else
-    samba-libs: nodeps
-      /usr/lib*/samba/libreplace*.so
-      /usr/lib*/samba/libwinbind-client*.so
-  endif
+  samba-libs: nodeps
+    /usr/lib*/samba/lib{replace,winbind-client,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
 endif
 
 rpm:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -381,6 +381,7 @@ nscd:
 
 shadow:
   /etc
+  /usr/etc
   /usr/bin
   /usr/sbin/pwunconv
   /usr/sbin/chpasswd


### PR DESCRIPTION
## Problem

`installation-images` package does not build in current Factory staging projects.

## Solution

- more samba libs are needed due to samba dependency changes
- the move to `/usr/etc` in pam and shadow needs additional adjustments

## Bonus

- `multipath-tools` removed from initrd (it tries to include a directory that no longer exists)
- include correct directory for udev rules in `virtualbox-guest-tools`