### PR TITLE
fix initial sshd key generation

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -325,9 +325,8 @@ nfs-client:
 
 openssh:
   /
-  d /etc/sysconfig
-  t /etc/sysconfig/ssh
   E prein
+  E postin
   # enable root login bsc#1118114
   R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
 

--- a/data/root/etc/inst_setup_ssh
+++ b/data/root/etc/inst_setup_ssh
@@ -43,7 +43,7 @@ if [ ! -z "$sshpassword" ] ; then
 fi
 chown -R 0.0  /etc/ssh /root /etc/shadow 2>/dev/null
 
-/usr/sbin/sshd-gen-keys-start
+ssh-keygen -A
 
 echo -n "Starting SSH daemon... "
 
@@ -62,4 +62,3 @@ if [ ! "$SSH_FAILED" ] ; then
 fi
 
 [ -f /proc/splash ] && echo verbose >/proc/splash
-


### PR DESCRIPTION
## Problem

You cannot connect via ssh to installation/rescue system.

## Analysis

openssh changed to rely on a setting in `/etc/sysconfig/ssh` to trigger sshd key generation.

## Solution

- inst-sys: call ssh-keygen directly instead of the sshd-gen-keys-start wrapper script
- rescue: run openssh postin script to ensure the proper settings are created