### PR TITLE
include yast2-schema package (bsc#1153746)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -103,7 +103,6 @@ udev: ignore
 unzip: ignore
 ?dracut: ignore
 ?mkinitrd: ignore
-yast2-schema: ignore
 # handle yast2-registration -> suse-connect -> zypper dependency,
 # yast does not need zypper, just suse-connect, so ignore it
 ?zypper: ignore


### PR DESCRIPTION
## Problem

`yast2-schma` package is needed in connection with https://github.com/yast/yast-autoinstallation/pull/534

## Solution

Don't exclude it.