### PR TITLE
Added linuxrc reboot_timeout option

### DIFF
--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -75,7 +75,7 @@ e echo "defaultrepo:	`default_repo`" >>linuxrc.config
 
 e echo "KexecReboot:    1" >>linuxrc.config
 
-e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct" >>linuxrc.config
+e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout" >>linuxrc.config
 
 if YAST_SELFUPDATE ne ""
   e echo "SelfUpdate:	<YAST_SELFUPDATE>" >>linuxrc.config


### PR DESCRIPTION
@okurz is adding some patches in order to set the reboot timeout through linuxrc

See https://bugzilla.suse.com/show_bug.cgi?id=1122493

This PR is just for helping him with the changes needed.

See: https://github.com/yast/yast-yast2/pull/977 & https://github.com/yast/yast-installation/pull/823