### PR TITLE
etc: update module.config to match 5.4-final

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -166,7 +166,7 @@ xen-scsifront
 xen-scsiback
 
 virtio_blk
-virtio_fs
+virtiofs
 virtio_net
 net_failover
 virtio_scsi


### PR DESCRIPTION
The `virtio_fs` module added in 5.4-rc1 was renamed to `virtiofs` in
5.4-rc6 by https://github.com/torvalds/linux/commit/112e72373d1f (virtio-fs: Change module name to virtiofs.ko).
So fix the config accordingly.