### PR TITLE
etc: module.config, fix build on i586 with 5.4 kernel

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -195,7 +195,7 @@ kernel/drivers/pinctrl/.*
 kernel/drivers/platform/.*
 kernel/drivers/regulator/.*
 kernel/drivers/staging/hv/.*
-kernel/drivers/usb/common/usb-conn-gpio.ko.xz
+kernel/drivers/usb/common/usb-conn-gpio.ko
 kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/video/.*
 kernel/drivers/virtio/.*


### PR DESCRIPTION
Sorry, I am stupid. I left `.xz` in place when doing the 5.4 support and
the build fails on i586 where we don't compress modules (not sure why,
that would be a mistake, but this is incorrect anyway). And I don't test
i586.