### PR TITLE
prepare for syslinux 6.x setup (jsc#SLE-2969)

### DIFF
--- a/data/boot/boot.file_list
+++ b/data/boot/boot.file_list
@@ -13,10 +13,19 @@ if arch eq 'i386' || arch eq 'x86_64'
   memtest86+:
     m /boot/memtest.bin /loader/memtest
 
-  syslinux:
-    m /usr/share/syslinux/isolinux.bin /loader
-    m /usr/share/syslinux/gfxboot.c32 /loader
-    e isolinux-config --base=/boot/<arch>/loader loader/isolinux.bin
+  if exists(syslinux6)
+    syslinux6:
+      m /usr/share/syslinux/isolinux.bin /loader
+      m /usr/share/syslinux/gfxboot.c32 /loader
+      m /usr/share/syslinux/ldlinux.c32 /loader
+      m /usr/share/syslinux/libcom32.c32 /loader
+      e isolinux-config --base=/boot/<arch>/loader loader/isolinux.bin
+  else
+    syslinux:
+      m /usr/share/syslinux/isolinux.bin /loader
+      m /usr/share/syslinux/gfxboot.c32 /loader
+      e isolinux-config --base=/boot/<arch>/loader loader/isolinux.bin
+  endif
 
 elsif arch eq 'aarch64'
   <kernel_rpm>:

--- a/data/boot/theme.file_list
+++ b/data/boot/theme.file_list
@@ -4,10 +4,15 @@ if arch eq 'i386' || arch eq 'x86_64'
 
   gfxboot-branding-<gfxboot_theme>:
     /
-    e cp -a etc/bootsplash/themes/<gfxboot_theme>/cdrom/* loader
-    # e gfxboot --config-file=loader/gfxboot.cfg --change-config install::dud.url=http://download.opensuse.org/update/openSUSE/driverupdate
-    e gfxboot --config-file=loader/gfxboot.cfg --change-config product="<product_name>"
-    e gfxboot --config-file=loader/gfxboot.cfg --change-config mainmenu.title="<product_name>"
+    if exists(syslinux6)
+      e gfxboot -a etc/bootsplash/themes/<gfxboot_theme>/cdrom --pack-archive loader/bootlogo
+      e gfxboot -a loader/bootlogo --change-config product="<product_name>"
+      e gfxboot -a loader/bootlogo --change-config mainmenu.title="<product_name>"
+    else
+      e cp -a etc/bootsplash/themes/<gfxboot_theme>/cdrom/* loader
+      e gfxboot --config-file=loader/gfxboot.cfg --change-config product="<product_name>"
+      e gfxboot --config-file=loader/gfxboot.cfg --change-config mainmenu.title="<product_name>"
+    endif
 
   r etc var
 

--- a/install.i386
+++ b/install.i386
@@ -52,7 +52,7 @@ for theme in $THEMES ; do
     mv $dir/initrd $dir/loader/initrd
     # check for syslinux 6.x setup
     if [ ! -e $dir/loader/gfxboot.cfg ] ; then
-      gfxboot -a $dir/loader/bootlogo --change-config install::initrd.size=$(stat -c "%s" $dir/loader/initrd)
+      tmp/base/usr/sbin/gfxboot -a $dir/loader/bootlogo --change-config install::initrd.size=$(stat -c "%s" $dir/loader/initrd)
     fi
   fi
 

--- a/install.i386
+++ b/install.i386
@@ -47,8 +47,13 @@ for theme in $THEMES ; do
   mkdir -p $DESTDIR/branding/$theme/CD1/boot/$ARCH/loader
 
   # initrd goes to 'loader' dir
-  if [ -e $DESTDIR/branding/$theme/CD1/boot/$ARCH/initrd ] ; then
-    mv $DESTDIR/branding/$theme/CD1/boot/$ARCH/initrd $DESTDIR/branding/$theme/CD1/boot/$ARCH/loader/initrd
+  dir=$DESTDIR/branding/$theme/CD1/boot/$ARCH
+  if [ -e $dir/initrd ] ; then
+    mv $dir/initrd $dir/loader/initrd
+    # check for syslinux 6.x setup
+    if [ ! -e $dir/loader/gfxboot.cfg ] ; then
+      gfxboot -a $dir/loader/bootlogo --change-config install::initrd.size=$(stat -c "%s" $dir/loader/initrd)
+    fi
   fi
 
   # cp etc/README $DESTDIR/branding/$theme/CD1/boot/$ARCH


### PR DESCRIPTION
## Task

Prepare installation-images for differences between syslinux 6.x and 4.x.

See also https://github.com/openSUSE/gfxboot/pull/43.

Note that `syslinux6` and `syslinux` packages conflict. So there can't be both available.