### PR TITLE
add some missing pci controller modules (bsc#1159503)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -189,6 +189,7 @@ kernel/drivers/mailbox/.*
 kernel/drivers/md/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*
+kernel/drivers/pci/controller/.*
 kernel/drivers/pci/host/.*
 kernel/drivers/phy/.*
 kernel/drivers/pinctrl/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -242,6 +242,7 @@ kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/phy/
 kernel/drivers/regulator/
 kernel/drivers/pci/host/
+kernel/drivers/pci/controller/
 kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
 


### PR DESCRIPTION
## Task

https://bugzilla.suse.com/show_bug.cgi?id=1159503

- add  `vmd.ko` module

## Solution

- add all 3 modules from `kernel/drivers/pci/controller/`