### PR TITLE
fix initial sshd key generation

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -294,7 +294,14 @@ dbus-1:
   # not needed
   r /usr/bin/dbus-launch*
   E prein
+
+  # The chmod commands are an evil hack to avoid running chkstat - which
+  # would fail and pass a non-zero exit code as it happens to be the last
+  # command in dbus-1's postin (see bsc#1160594).
+  #
+  E chmod -x /usr/bin/chkstat
   E postin
+  E chmod +x /usr/bin/chkstat
 
 polkit:
   /

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -326,9 +326,8 @@ nfs-client:
 
 openssh:
   /
-  d /etc/sysconfig
-  t /etc/sysconfig/ssh
   E prein
+  E postin
 
 ?ia32el:
   /etc/init.d/ia32el

--- a/data/root/etc/inst_setup_ssh
+++ b/data/root/etc/inst_setup_ssh
@@ -43,7 +43,7 @@ if [ ! -z "$sshpassword" ] ; then
 fi
 chown -R 0.0  /etc/ssh /root /etc/shadow 2>/dev/null
 
-/usr/sbin/sshd-gen-keys-start
+ssh-keygen -A
 
 echo -n "Starting SSH daemon... "
 
@@ -62,4 +62,3 @@ if [ ! "$SSH_FAILED" ] ; then
 fi
 
 [ -f /proc/splash ] && echo verbose >/proc/splash
-


### PR DESCRIPTION
## Problem

SLE-12-SP5:Update got changes that break `installation-images` building.

1. `sshd-gen-keys-start` does not generate sshd keys
2. `dbus-1` postin script fails

## Solution

1.  a backport of https://github.com/openSUSE/installation-images/pull/340 is needed
2. avoid running `chkstat` in `dbus-1`'s postin script; it's (accidentally) the last command and its exit code is passed on; `chkstat` fails after security hardening because `/proc` is not mounted

I'm aware that 2. is not particularly elegant but it gets the job done. The same issue does not appear in later SUSE releases as there `chkstat` is not the last command.