### PR TITLE
udevd compat symlink has been removed from udev package

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -575,6 +575,9 @@ include theme.file_list
 
 :
 
+# keep this udevd compat symlink, it's no longer in the latest udev package
+s /usr/lib/systemd/systemd-udevd /sbin/udevd
+
 # replace issue and motd with our own messages
 include texts.file_list
 


### PR DESCRIPTION
## Problem

The compat symlink 

`/sbin/udevd -> /usr/lib/systemd/systemd-udevd`

is no longer included in the udev package

## Solution

Add the link explicitly. It's a nice thing to have and we can keep existing scripts.