### PR TITLE
add /sbin/udevadm compat symlink for the moment (bsc#1160890)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -578,6 +578,9 @@ include theme.file_list
 # keep this udevd compat symlink, it's no longer in the latest udev package
 s /usr/lib/systemd/systemd-udevd /sbin/udevd
 
+# add the compat link for the moment (bsc#1160890)
+s /usr/bin/udevadm /sbin/udevadm
+
 # replace issue and motd with our own messages
 include texts.file_list
 


### PR DESCRIPTION
## Problem

`/sbin/udevadm` compat symlink is gone from udev package.

## Solution

Add it here for the moment until all tools have been adjusted.