### PR TITLE
s390x: I/O device pre-configuration (jsc#SLE-7396)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -80,3 +80,7 @@ while read ifname xxx ; do
 done < <(/etc/wicked/extensions/ibft -l)
 echo "ibftdevices: $ibft" >/etc/ibft_devices
 
+# s390x: I/O device pre-configuration (jsc#SLE-7396)
+if [ -x /sbin/chzdev -a -e /sys/firmware/sclp_sd/config/data ] ; then
+  /sbin/chzdev --import /sys/firmware/sclp_sd/config/data
+fi


### PR DESCRIPTION
## Task

Trello:  https://trello.com/c/GlWzCK8w
Jira dev: https://jira.suse.com/browse/SLE-10829
Jira epic: https://jira.suse.com/browse/SLE-7396

Run `chzdev --import ...` if needed at the beginning of the installation.

## Solution

Add the call to the early_setup script. This script is run by linuxrc before starting the hardware config but **after** udevd has been started.