### PR TITLE
remove obsolete net-tools package

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -65,6 +65,7 @@ device-mapper:
 ethtool:
 glibc:
 haveged:
+hostname:
 hwinfo:
 iputils:
 iscsiuio:
@@ -73,8 +74,6 @@ kmod-compat:
 krb5:
 lsscsi:
 mdadm:
-net-tools:
-?net-tools-deprecated:
 nvme-cli:
 sed:
 ?wicked:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -37,12 +37,10 @@ TEMPLATE:
 
 # install filesystem first and *REMOVE* /var/run link
 filesystem:
-  /etc/{ppp,rc.d,uucp}
   /etc/sysconfig
   /root
   /run
   /etc/init.d
-  /usr/tmp
   /var
   # remove temporarily so that 'mount /sys' doesn't work
   r /sys
@@ -110,6 +108,7 @@ grep:
 gzip:
 hdparm:
 hex:
+hostname:
 hwinfo:
 icmpinfo:
 initviocons:
@@ -127,8 +126,6 @@ krb5:
 lsscsi:
 mingetty:
 ncurses-utils:
-net-tools:
-?net-tools-deprecated:
 netcat-openbsd:
 nscd:
 ntfsprogs:
@@ -182,14 +179,6 @@ if filelist ne 'rescue-server'
     /usr/lib*/samba/lib{replace,winbind-client,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
 endif
 
-rpm:
-  /bin
-  /usr/bin
-  /{usr,var}/lib/rpm
-  /usr/lib*/librpm*.so.*
-r /usr/lib/rpm/rpm{get,put}text
-r /usr/bin/rpmqpack
-
 gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
@@ -211,8 +200,7 @@ endif
   e cp -a /tmp/locale usr/lib
 
 less:
-  /etc
-  /usr/bin
+  /
   r /usr/bin/lesspipe.sh
   t /usr/bin/lesspipe.sh
   c 0755 0 0 /usr/bin/lesspipe.sh
@@ -281,6 +269,10 @@ s /usr/bin/true /sbin/mkinitrd_setup
 # packages with scripts
 #
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+rpm:
+  /
+  E postin
 
 aaa_base:
   E prein

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -152,8 +152,6 @@ libyui-qt-graph*:
 ?ltrace:
 lvm2:
 multipath-tools:
-net-tools:
-?net-tools-deprecated:
 ntfsprogs:
 open-iscsi:
 openslp:
@@ -255,6 +253,7 @@ diffutils:
 
 less:
   /etc/lesskey
+  /usr/etc/lesskey
   /usr/bin/less
 
 strace:

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -29,12 +29,10 @@ TEMPLATE:
 
 # install filesystem first and *REMOVE* /var/run link
 filesystem:
-  /etc/{ppp,rc.d,uucp}
   /etc/sysconfig
   /root
   /run
   /etc/init.d
-  /usr/tmp
   /var
   # remove temporarily so that 'mount /sys' doesn't work
   r /sys
@@ -59,6 +57,7 @@ grep:
 gzip:
 hdparm:
 hex:
+hostname:
 hwinfo:
 initviocons:
 insserv-compat:
@@ -67,8 +66,6 @@ iputils:
 joe:
 klogd:
 lvm2:
-net-tools:
-?net-tools-deprecated:
 ntfsprogs:
 open-iscsi:
 parted:
@@ -129,6 +126,7 @@ ncurses-utils:
 
 less:
   /etc/lesskey
+  /usr/etc/lesskey
   /usr/bin/less
 
 psmisc:


### PR DESCRIPTION
## Problem

`net-tools` and `net-tools-deprecated` should no longer be used.

## Solution

Remove them. As `net-tools` required `hostname`, add it explicitly.

## Bonus

Clean up some other minor issues.