### PR TITLE
remove explicit dependency on openssl package

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -83,7 +83,6 @@ make:
 mkfontscale:
 kmod-compat:
 openslp:
-openssl:
 p11-kit-tools:
 p11-kit:
 pam:
@@ -111,12 +110,7 @@ util-linux:
 <release_theme>-release: nodeps
 
 ca-certificates:
-  /usr/sbin/update-ca-certificates
-  /usr/lib/ca-certificates/update.d/*openssl.run
-  /usr/lib/ca-certificates/update.d/*etc_ssl.run
-  /var/lib/ca-certificates/openssl
-  /etc/ssl/certs
-  /var/lib/ca-certificates/pem
+  /
 
 aaa_base:
   E prein

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -46,7 +46,6 @@ keyutils: ignore
 libcrack*: ignore
 libmagic*: ignore
 logrotate: ignore
-openssl: ignore
 permissions: ignore
 pinentry: ignore
 suspend: ignore

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -361,16 +361,6 @@ cracklib: nodeps
   x etc/ssh /lib
   x ../rescue/mount-rootfs-and-do-chroot.sh /bin
 
-if exists(openssl, /usr/share/ssl)
-  openssl:
-else
-  # FIXME: for now, ignore old version, else the solver will have multiple
-  # choices and things go down...
-  openssl-1_0_0: ignore
-  openssl-*:
-endif
-  /usr/share/ssl
-
 nscd:
   /etc
   /usr

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -155,13 +155,6 @@ netcfg:
   x etc/ssh /lib
   x ../rescue/mount-rootfs-and-do-chroot.sh /bin
 
-if exists(openssl, /usr/share/ssl)
-  openssl:
-else
-  openssl-*:
-endif
-  /usr/share/ssl
-
 dmidecode:
   /usr/sbin/dmidecode
 

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -189,6 +189,7 @@ sub resolve_deps_obs;
 sub resolve_deps_libsolv;
 sub show_package_deps;
 sub get_version_info;
+sub version_cmp;
 
 my ($arch, $realarch, $susearch);
 
@@ -284,7 +285,7 @@ sub RealRPM
 
     return $rpmData->{$rpm_orig} = undef if @f == 0;
 
-    @f = sort @f;
+    @f = sort { &version_cmp } @f;
     # for (@f) { print ">$_<\n"; }
     $f = pop @f;
     $f = pop @f if $back;
@@ -539,20 +540,6 @@ sub KernelImg
   }
 
   return @k_images;
-}
-
-
-sub version_sort
-{
-  my ($i, $j);
-
-  $i = $ConfigData{ini}{Version}{$a};
-  $j = $ConfigData{ini}{Version}{$b};
-
-  $i =~ s/,([^,]+)//;
-  $j =~ s/,([^,]+)//;
-
-  return $i <=> $j;
 }
 
 
@@ -944,6 +931,23 @@ sub get_version_info
   # print "dist=\"$dist\"\n";
 
   $ConfigData{os}{update} = "/linux/suse/$realarch-$dist";
+}
+
+
+# compare version strings
+#
+# Ensuring that e.g. 'foo11' comes after 'foo4'.
+#
+sub version_cmp
+{
+  my $x = $a;
+  my $y = $b;
+
+  # assume numbers will have at most 10 digits...
+  $x =~ s/(\d+)/sprintf "%010s", $1/eg;
+  $y =~ s/(\d+)/sprintf "%010s", $1/eg;
+
+  return $x cmp $y;
 }
 
 


### PR DESCRIPTION
## Task

1. `openssl` is gone. It was basically empty anyway. `libssl` is included via package dependencies where needed.

2. `/proc/self/fd` is needed by a number of programs. See https://bugzilla.suse.com/show_bug.cgi?id=1160594.

3. Picking the latest package version did not work correctly. Think `foo9` vs. `foo10`.

## Solution

1. Do not include `openssl` explicitly.

2. Mount `/proc` in chroot environment when running package pre/post scripts.

3. Fix package version comparing.