### PR TITLE
move gconv files into initrd (bsc#1161701)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -73,6 +73,7 @@ kmod-compat:
 krb5:
 lsscsi:
 mdadm:
+netcfg:
 nvme-cli:
 sed:
 ?wicked:
@@ -130,12 +131,6 @@ terminfo-base:
 
 terminfo:
   /usr/share/terminfo/i/ibm3151
-
-netcfg:
-  /etc/hosts
-  /etc/netgroup
-  /etc/protocols
-  /etc/services
 
 ?xf86-input-vmmouse:
   /usr/bin/vmmouse_detect

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -403,6 +403,22 @@ autoyast2-installation: nodeps
 lvm2: nodeps
   /etc
 
+# note: locale files are added in root image
+if exists(glibc-locale-base)
+  glibc-locale: ignore
+  glibc-locale-base:
+else
+  glibc-locale:
+endif
+  # charset encodings we might possibly need
+  /usr/lib*/gconv/IBM1047.so
+  /usr/lib*/gconv/ISO8859-1.so
+  /usr/lib*/gconv/UNICODE.so
+  /usr/lib*/gconv/UTF-16.so
+  /usr/lib*/gconv/UTF-32.so
+  /usr/lib*/gconv/gconv-modules*
+
+
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #
 # packages with scripts

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -189,11 +189,13 @@ if exists(glibc-locale-base)
 else
   glibc-locale:
 endif
-  /usr/lib*/gconv/ISO8859*
-  /usr/lib*/gconv/KOI*
-  /usr/lib*/gconv/UNICODE*
-  /usr/lib*/gconv/gconv-modules*
+  # charset encodings we might possibly need
   /usr/lib*/gconv/IBM1047.so
+  /usr/lib*/gconv/ISO8859-1.so
+  /usr/lib*/gconv/UNICODE.so
+  /usr/lib*/gconv/UTF-16.so
+  /usr/lib*/gconv/UTF-32.so
+  /usr/lib*/gconv/gconv-modules*
 
   # built in base system
   d usr/lib

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -127,6 +127,7 @@ lsscsi:
 mingetty:
 ncurses-utils:
 netcat-openbsd:
+netcfg:
 nscd:
 ntfsprogs:
 nvme-cli:
@@ -212,10 +213,6 @@ less:
   r /usr/bin/lessclose.sh
   t /usr/bin/lessclose.sh
   c 0755 0 0 /usr/bin/lessclose.sh
-
-netcfg:
-  /etc
-  r /etc/{diphosts,ftpusers,hosts.*}
 
 ntfs-3g:
   /

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -398,20 +398,13 @@ gpg2:
 # needed for one time ntp sync
 chrony:
 
+# note: gconv files are in initrd
 if exists(glibc-locale-base)
   glibc-locale: ignore
   glibc-locale-base:
 else
   glibc-locale:
 endif
-  /usr/lib*/gconv/ISO8859*
-  /usr/lib*/gconv/KOI*
-  /usr/lib*/gconv/UNICODE*
-  /usr/lib*/gconv/UTF-16.so
-  /usr/lib*/gconv/UTF-32.so
-  /usr/lib*/gconv/gconv-modules*
-  /usr/lib*/gconv/IBM1047.so
-
   # built in base system
   d usr/lib
   e cp -a /tmp/locale usr/lib

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -66,6 +66,7 @@ iputils:
 joe:
 klogd:
 lvm2:
+netcfg:
 ntfsprogs:
 open-iscsi:
 parted:
@@ -141,9 +142,6 @@ x /etc/ld.so.conf /etc
 
 # remove these:
 r root mnt tmp usr/libexec
-
-netcfg:
-  /etc/{services,protocols}
 
 :
   r /lib*/security/pam_userdb.so


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1161701

On s390 some charset conversions are needed in linuxrc.

## Solution

Move gconv files into initrd. Also, clean up the list of gconv files to include:

- IBM1047 & ISO8859-1 are needed for s390
- everything else should be Unicode

## Bonus

- `netcfg` package has moved its content to `/usr/etc`. Adjust accordingly.