### PR TITLE
etc: update module.config to match 5.6

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -317,20 +317,21 @@ xen-vnif,"Xen Network"
 vxlan
 af_packet_diag
 
-kernel/drivers/net/hyperv/.*
-kernel/drivers/net/team/.*
+kernel/drivers/misc/sgi-xp/.*
+kernel/drivers/net/can/.*
+kernel/drivers/net/dsa/.*
 kernel/drivers/net/ethernet/.*
 kernel/drivers/net/fddi/.*
-kernel/drivers/net/tokenring/.*
-kernel/drivers/net/can/.*
-kernel/drivers/net/phy/.*
+kernel/drivers/net/hyperv/.*
 kernel/drivers/net/ieee802154/.*
 kernel/drivers/net/ipvlan/.*
-kernel/drivers/net/dsa/.*
-kernel/drivers/misc/sgi-xp/.*
+kernel/drivers/net/phy/.*
+kernel/drivers/net/team/.*
+kernel/drivers/net/tokenring/.*
+kernel/drivers/net/wireguard/.*
 kernel/net/ieee802154/.*
-kernel/net/mac802154/.*
 kernel/net/ipv4/.*
+kernel/net/mac802154/.*
 
 
 [WLAN]


### PR DESCRIPTION
5.6 added wireguard, a replacement for IPSec. Let's put it to [network]
along with other network modules.

While at it, sort the paths alphabetically.