### PR TITLE
Update module list for 5.5:

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -126,6 +126,7 @@ bcm2835-dma
 bcma
 caif_hsi
 ptp
+ptp_clockmatrix
 ptp_kvm
 ptp_pch
 ptp_dte


### PR DESCRIPTION
on aarch64 build fails with:

  error: nothing known about "kernel/drivers/ptp/ptp_clockmatrix.ko.xz"
  make: *** [Makefile:118: initrd+modules+gefrickel] Error 11