### PR TITLE
etc: ptp_clockmatrix to module.config

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -126,6 +126,7 @@ bcm2835-dma
 bcma
 caif_hsi
 ptp
+ptp_clockmatrix
 ptp_kvm
 ptp_pch
 ptp_dte


### PR DESCRIPTION
We enabled it in tumbleweed, but `module.config` does not list it yet.
Let's put it to `[other]` along with other ptp modules.