### PR TITLE
adapt system-user-* and system-group-* package handling (bsc #1163938)

### DIFF
--- a/data/rescue/rescue-server.file_list
+++ b/data/rescue/rescue-server.file_list
@@ -6,6 +6,9 @@ vsftpd:
   /
   E prein
 
+system-user-ftp:
+system-user-lp:
+
 ftp:
 nfs-kernel-server:
 samba:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -21,6 +21,12 @@ TEMPLATE binutils:
   r /usr/bin/ld
   s ld.bfd /usr/bin/ld
 
+TEMPLATE system-user-root: direct
+
+TEMPLATE system-user-.*|system-group-.*:
+  /
+  E prein
+
 TEMPLATE nfs-client|device-mapper|rpcbind|rsync|rsyslog|dmraid|multipath-tools:
   /
   E prein
@@ -29,8 +35,6 @@ TEMPLATE nfs-client|device-mapper|rpcbind|rsync|rsyslog|dmraid|multipath-tools:
 TEMPLATE wicked|lvm2|syslog-service|util-linux|mdadm:
   /
   E postin
-
-TEMPLATE system-user-root: direct
 
 TEMPLATE:
   /
@@ -156,6 +160,7 @@ sysconfig:
 sysconfig-netconfig:
 systemd-presets-branding-<systemd_theme>:
 systemd-sysvinit:
+sysuser-shadow:
 tar:
 terminfo-base:
 usbutils:
@@ -268,6 +273,9 @@ s /usr/bin/true /sbin/mkinitrd_setup
 # packages with scripts
 #
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+system-group-hardware:
+system-user-nobody:
 
 rpm:
   /


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1163938
- https://trello.com/c/efKuF0uZ

`rpc` user is missing in rescue system. (And also others.)

## Solution

Users and groups are created in `system-user-*` and `system-group-*` packages in RPM preinstall scripts.

It is a bit hard to have these handled automatically as they have incorrect dependencies and there is also a dependency loop.

The patch takes care of known users and groups handled this way. Also, the build will break in future if new users/groups appear and are not handled correctly.

Note

> The `rpc` user could not be created in `rpcbind` because the `nobody` group was missing (it's in `system-user-nobody`).