### PR TITLE
use u-boot-rpiarm64 if available (bsc#1164080)

### DIFF
--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -66,8 +66,13 @@ if arch eq 'aarch64' && exists(raspberrypi-firmware)
     /
   raspberrypi-firmware-dt:
     /
-  u-boot-rpi3:
-    /
+  if exists(u-boot-rpiarm64)
+    u-boot-rpiarm64:
+      /
+  else
+    u-boot-rpi3:
+      /
+  endif
   e mv boot/vc/* .
   r /boot /usr
 endif


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1164080#c6

Use new `u-boot-rpiarm64` package instead of `u-boot-rpi3` for aarch64 builds.