### PR TITLE
don't bind-mount / in rescue system (bsc#1160449)

### DIFF
--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -74,10 +74,6 @@ if [ -d /mounts/initrd/update ] ; then
   done
 fi
 
-# ensure there's a mountpoint for /, else udevd will have problems
-# cf. bsc #937237, comment 51
-mount --bind / /
-
 if [ "$startshell" = 1 ] ; then
   echo "exit shell to continue startup process..."
   bash >/dev/console 2>&1


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1160449
- https://bugzilla.suse.com/show_bug.cgi?id=1161138

`/etc/mtab` is a symlink to `../proc/self/mounts`. This does not work with the `mount --bind / /` that's done during rescue system setup.

It leads to problems traversing relative symlinks.

## Solution

Remove it.

It has been added for https://bugzilla.suse.com/show_bug.cgi?id=937237 but that seems no longer necessary.

## See also

This is a port of https://github.com/openSUSE/installation-images/pull/355 for branch `sle15-sp1`.