### PR TITLE
samba-libs needs libgnutls now

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -117,6 +117,9 @@ libzypp: nodeps
 samba-libs: nodeps
   /usr/lib*/samba/lib{replace,winbind-client,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
 
+# for samba-libs
+libgnutls*:
+
 diffutils:
   /usr/bin/cmp
 


### PR DESCRIPTION
## Problem

`samba-libs` needs `libgnutls`.

## Solution

The dependency must be added explicitly because samba-libs has a huge dependency list - most of which we don't need.