### PR TITLE
put S390 I/O device pre-config into a separate script (bsc#1168036)

### DIFF
--- a/data/initrd/scripts/device_auto_config
+++ b/data/initrd/scripts/device_auto_config
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+exec >&2
+
+# s390x: I/O device pre-configuration (jsc#SLE-7396)
+if [ -x /sbin/chzdev -a -e /sys/firmware/sclp_sd/config/data ] ; then
+  /sbin/chzdev --import /sys/firmware/sclp_sd/config/data
+fi

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -79,8 +79,3 @@ while read ifname xxx ; do
   ibft="$ibft$ifname"
 done < <(/etc/wicked/extensions/ibft -l)
 echo "ibftdevices: $ibft" >/etc/ibft_devices
-
-# s390x: I/O device pre-configuration (jsc#SLE-7396)
-if [ -x /sbin/chzdev -a -e /sys/firmware/sclp_sd/config/data ] ; then
-  /sbin/chzdev --import /sys/firmware/sclp_sd/config/data
-fi


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1168036
- https://jira.suse.com/browse/SLE-7396

I/O device pre-configuration should not be used unconditionally. The user needs a way to avoid it.

## Solution

Separate the configuration call so linuxrc can decide whether to do it.

## See also

- related linuxrc change: https://github.com/openSUSE/linuxrc/pull/220