### PR TITLE
add missing vbox drivers (bsc#1168742)

### DIFF
--- a/etc/module.list
+++ b/etc/module.list
@@ -250,6 +250,9 @@ kernel/fs/efivarfs/
 
 kernel/drivers/dma/bcm2835-dma.ko
 
+kernel/fs/vboxsf/
+kernel/drivers/virt/vboxguest/
+
 # kmps
 updates/
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1168742

Virtualbox client installation doesn't work properly. Some vbox kernel drivers are missing.

## Solution

Fix config so that the missing modules are (again) available.