### PR TITLE
avoid python3-numpy

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -198,6 +198,11 @@ python3-websockify:
   # avoid update-alternatives
   e cd usr/bin ; if [ -f websockify-3.* ] ; then ln -snf websockify-3.* websockify ; fi
 
+# normally python3-websockify would require python3-numpy but the
+# dependency is actually optional in the code - so avoid it to
+# save **a lot** of space
+python3-numpy: ignore
+
 vim:
   /
   # avoid update-alternatives


### PR DESCRIPTION
## Problem

python3-numpy now uses update-alternatives.

## Solution

Take the opportunity to drop python3-numpy. python3-websockify doesn't strictly require it. This saves about 12.5 MiB **xz-compressed** data.

Before:
```
-rw-r--r-- 1 root root 85458944 Apr 16 12:56 root
```

After:
```
-rw-r--r-- 1 root root 72744960 Apr 16 12:57 root
```

## Rant

python3-websockify is a small (440 kiB) package. It drags in a 20 MiB python3-numpy - which in turn requires weird things like fortran math libs and whatever.

And what for? To 'speed up' xor-ing a buffer. Yeah. Really worth it.