### PR TITLE
etc: update module.config to match 5.7

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -127,10 +127,12 @@ bcma
 caif_hsi
 ptp
 ptp_clockmatrix
+ptp_dte
+ptp_idt82p33
 ptp_kvm
 ptp_pch
-ptp_dte
 ptp_qoriq
+ptp_vmw
 ptp-qoriq
 pps_core
 libore
@@ -610,6 +612,7 @@ kernel/arch/s390/.*
 
 ; modules we do _not_ need
 [notuseful]
+bareudp
 bpck6
 bsd_comp
 caif_serial


### PR DESCRIPTION
5.7 added `bareudp`, another tunneling module. Let's put it to `[notuseful]`
along with other tunnelling modules.

It added also two more `ptp` modules, put them to `[other]`, along with
other `ptp` modules. While at it, sort the `ptp` modules alphabetically.