### PR TITLE
beware of bash using update-alternatives

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -53,7 +53,12 @@ TEMPLATE:
 
 AUTODEPS:
 
+# it's using update-alternatives
 bash:
+  /bin/{sh,bash}
+  /usr/bin/bash
+  s bash usr/bin/sh
+
 binutils: ignore
 ca-certificates-mozilla:
 coreutils:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -218,9 +218,11 @@ coreutils:
   # linuxrc needs it in /bin
   m /usr/bin/rm bin
 
+# it's using update-alternatives
 bash:
   /bin/{sh,bash}
-  /usr/bin/{sh,bash}
+  /usr/bin/bash
+  s bash usr/bin/sh
   s bash /bin/lsh
 
 ncurses-utils:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -60,6 +60,12 @@ update-alternatives: ignore
 device-mapper-32bit: ignore
 binutils: ignore
 
+# it's using update-alternatives
+bash:
+  /bin/{sh,bash}
+  /usr/bin/bash
+  s bash usr/bin/sh
+
 ?acpica:
 ?efibootmgr:
 ?elilo:
@@ -79,7 +85,6 @@ binutils: ignore
 ?wpa_supplicant:
 aaa_base-extras:
 attr:
-bash:
 bc:
 bcache-tools:
 bind-utils:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -227,9 +227,11 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
+# it's using update-alternatives
 bash:
   /bin/{sh,bash}
-  /usr/bin/{sh,bash}
+  /usr/bin/bash
+  s bash usr/bin/sh
 
 nfs-client:
   /sbin/{u,}mount.nfs*

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -109,9 +109,11 @@ krb5:
   /usr/lib*/libgssapi_krb5.so.*
   /usr/lib*/libk5crypto.so.*
 
+# it's using update-alternatives
 bash:
   /bin/{sh,bash}
-  /usr/bin/{sh,bash}
+  /usr/bin/bash
+  s bash usr/bin/sh
 
 dbus-1: prein
   /


### PR DESCRIPTION
## Problem

`sh` is now just a link to `/etc/update-alternatives/sh`.

## Solution

Be ready.