### PR TITLE
support MicroOSNG (bsc#1170885)

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -144,6 +144,17 @@ plymouth          = openSUSE
 systemd           = MicroOS
 product_name      = openSUSE-Kubic
 
+[Theme MicroOSNG]
+image             = 350
+patch_zypp_config = 1
+release           = MicroOSNG
+skelcd            = MicroOSNG
+skelcd_ctrl       = MicroOSNG
+gfxboot           = SLE
+grub2             = SLE
+plymouth          = SLE
+systemd           = SLE
+
 [Theme MicroOS]
 image             = 350
 patch_zypp_config = 1


### PR DESCRIPTION
## Task

Support new MicroOSNG product.

## Solution

This extracts the required changes from [here](https://build.suse.de/package/show/SUSE:SLE-15-SP2:Update:Products:MicroOSNG/installation-images).