### PR TITLE
support Leap-based MicroOS (bsc#1171585)

### DIFF
--- a/etc/os_sample.txt
+++ b/etc/os_sample.txt
@@ -37,7 +37,7 @@ CPE_NAME="cpe:/o:opensuse:tumbleweed:20161125"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
 
-== leap ==
+== leap (old) ==
 
 NAME="openSUSE Leap"
 VERSION="42.1"
@@ -49,6 +49,19 @@ CPE_NAME="cpe:/o:opensuse:opensuse:42.1"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://opensuse.org/"
 ID_LIKE="suse"
+
+== leap ==
+
+NAME="openSUSE Leap"
+VERSION="15.0"
+ID="opensuse-leap"
+ID_LIKE="suse opensuse"
+VERSION_ID="15.0"
+PRETTY_NAME="openSUSE Leap 15.0"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:leap:15.0"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
 
 == openSUSE Kubic [obsolete] ==
 
@@ -83,7 +96,7 @@ CPE_NAME="cpe:/o:opensuse:tumbleweed-kubic:20170909"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
 
-== openSUSE MicroOS ==
+== openSUSE Tumbleweed MicroOS ==
 
 NAME="openSUSE MicroOS"
 # VERSION="20190301"
@@ -96,6 +109,18 @@ CPE_NAME="cpe:/o:opensuse:microos:20190301"
 BUG_REPORT_URL="https://bugs.opensuse.org"
 HOME_URL="https://www.opensuse.org/"
 
+== openSUSE Leap MicroOS ==
+
+NAME="openSUSE MicroOS"
+VERSION="15.2 Alpha"
+ID="opensuse-microos"
+ID_LIKE="suse opensuse opensuse-leap"
+VERSION_ID="15.2"
+PRETTY_NAME="openSUSE MicroOS 15.2 Alpha"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:opensuse:MicroOS:15.2"
+BUG_REPORT_URL="https://bugs.opensuse.org"
+HOME_URL="https://www.opensuse.org/"
 
 == sles12 ==
 

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -916,9 +916,20 @@ sub get_version_info
 
   die "*** unsupported product: $dist ***" if $dist !~ /^(casp|caasp|kubic|microos|microosng|leap|sles|sled|tumbleweed( kubic)?)$/;
 
-  my $is_tw = $dist =~ /^(microos|tumbleweed( kubic)?)$/;
+  # Kubic is based on TW
+  # MicroOS can be based on TW or Leap
 
-  # kubic uses 'tw' as dist tag
+  my $is_tw = $dist =~ /^tumbleweed( kubic)?$/;
+
+  if($dist eq "microos") {
+    if($config{ID_LIKE} =~ /tumbleweed/) {
+      $is_tw = 1;
+    }
+    elsif($config{ID_LIKE} =~ /leap/) {
+      $dist = "leap";
+    }
+  }
+
   $dist = $is_tw ? 'tw' : "$dist$config{VERSION_ID}";
 
   # there's no separate dist tag for service packs


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1171587

There is (will be) a MicroOS based on Leap. Create the expected driver update location for it.

## Solution

Use the `ID_LIKE` tag to differentiate between both variants.