### PR TITLE
ensure there's a writable /var/lib/rpm directory (bsc#1171733)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -293,6 +293,8 @@ rpm:
   /usr/bin/rpmkeys
   /usr/lib*/librpm{,io}.so.*
   /usr/lib/rpm/rpmrc
+  # the package contains a symlink to /usr, but we need it writable (bsc#1171733)
+  d var/lib/rpm
 
 squashfs:
   /usr/bin/mksquashfs


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1171733

`/var/lib/rpm` is a symlink to `/usr/lib/sysimage/rpm` - which is read-only. This leads to problems when zypper tries to write to `/var/lib/rpm`.

## Solution

Make `/var/lib/rpm` a writable directory.

## See also

This is a port of https://github.com/openSUSE/installation-images/pull/378 to SLE15-SP2.