### PR TITLE
follow xorg font file shuffle (xorg-x11-legacy, bsc#1169444)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -487,16 +487,29 @@ xdm:
 rgb:
   /usr/share/X11/rgb.txt
 
-xorg-x11-fonts-core:
-  # 'fixed' font
-  /usr/share/fonts/misc/6x13-ISO8859-1.pcf.gz
-  /usr/share/fonts/misc/fonts.alias
-  /usr/share/fonts/misc/cursor.pcf.gz
-  /usr/share/fonts/misc/6x13.pcf.gz
-  /usr/share/fonts/misc/olcursor.pcf.gz
+if exists(xorg-x11-fonts-legacy)
+  xorg-x11-fonts-core:
+    # 'fixed' font
+    /usr/share/fonts/misc/6x13-ISO8859-1.pcf.gz
+    /usr/share/fonts/misc/fonts.alias
+    /usr/share/fonts/misc/cursor.pcf.gz
+    /usr/share/fonts/misc/6x13.pcf.gz
 
-xorg-x11-fonts:
-  m /usr/share/fonts/75dpi/helvB14-ISO8859-1.pcf.gz /usr/share/fonts/misc
+  xorg-x11-fonts-legacy:
+    /usr/share/fonts/misc/olcursor.pcf.gz
+    m /usr/share/fonts/75dpi/helvB14-ISO8859-1.pcf.gz /usr/share/fonts/misc
+else
+  xorg-x11-fonts-core:
+    # 'fixed' font
+    /usr/share/fonts/misc/6x13-ISO8859-1.pcf.gz
+    /usr/share/fonts/misc/fonts.alias
+    /usr/share/fonts/misc/cursor.pcf.gz
+    /usr/share/fonts/misc/6x13.pcf.gz
+    /usr/share/fonts/misc/olcursor.pcf.gz
+
+  xorg-x11-fonts:
+    m /usr/share/fonts/75dpi/helvB14-ISO8859-1.pcf.gz /usr/share/fonts/misc
+endif
 
   d /etc/X11
   x /etc/xorg.conf.template /etc/X11


### PR DESCRIPTION
# Task

* https://bugzilla.suse.com/show_bug.cgi?id=1169444

xorg font packages were reorganized. There's now xorg-x11-fonts-legacy.

Adjust to these changes.
This is based on #381 by @wfeldt

# See also
same for master: #382