### PR TITLE
Add missed file to instsys.

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -275,6 +275,7 @@ endif
 ?sap-installation-wizard: nodeps
   /usr/share/YaST2/clients/sap_proposal.rb
   /usr/share/YaST2/clients/inst_sap-start.rb
+  /usr/share/YaST2/lib/y2system_role_handlers/sles4sap_role_finish.rb
 
 yast2:
   /etc


### PR DESCRIPTION
bsc#1158522 [Build 101.1] openQA test fails in windows_client_remotelogin