### PR TITLE
Add /bin/dash to reduce script memory consumption (bsc#1172139)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -233,6 +233,13 @@ bash:
   /usr/bin/bash
   s bash usr/bin/sh
 
+# Note that this does not make it the default shell /bin/sh,
+# only scripts that explicitly want dash will use it,
+# so we are safe even if there are undetected bashisms in some scripts.
+dash:
+  /bin/dash
+  /usr/bin/dash
+
 nfs-client:
   /sbin/{u,}mount.nfs*
   /usr/sbin/rpc.statd


### PR DESCRIPTION
This is a part of an overall effort to reduce the memory requirements of installing with YaST. For the big picture, see the main PR,  https://github.com/yast/yast-installation/pull/864 (aka `memsample`)

- Trello: https://trello.com/c/2RY7fqpT/1891-8-research-study-and-maybe-reduce-memory-consumption
- Bug: https://bugzilla.suse.com/show_bug.cgi?id=1172139

With bash, memsample and its pipe-created subshell take up 3452+2032=5484 KiB RSS.
With dash, it's 1768+160=1928 KiB :)
The dash binary has 119 KiB so it easily pays for itself.

Note that this does not make it the default shell /bin/sh,
only scripts that explicitly want dash will use it,
so we are safe even if there are undetected bashisms in some scripts.

An obvious next step would be making dash the default sh shell in hope of more memory savings but it is likely things will break so testing is needed beforehand.

A necessary BuildRequires addition is in https://build.opensuse.org/request/show/815496