### PR TITLE
Add YaST dir

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -10,6 +10,7 @@ d var/lib/systemd/migrated var/lib/polkit var/lib/sshd var/lib/empty
 d var/log/cups var/log/YaST2 var/log/zypp
 d var/spool var/run/libstorage var/run/hotplug var/run/ntp
 d run/dbus run/lock
+d usr/share/YaST2
 
 s /run/lock /var/lock
 s /run/lock /var/spool/locks


### PR DESCRIPTION
## Problem

TW installation fails when /usr/share/YaST2 is a symlink initially and then it is changed.

* https://bugzilla.suse.com/show_bug.cgi?id=1172898
* https://trello.com/c/5GQCm9Ol/1902-ostumbleweed-p5-1172898-tw-2020-06-11-installation-internal-error-undefined-method-start-for-class-yast2systemdtarget-in-instfin

## Solution

Include an empty /usr/share/YaST2 directory in initrd to ensure that its content (e.g., lib/) is a symlink from the very beginning.

NOTE: The real bug is in ruby2.7. This is only a workaround to avoid its effects for the time being. See https://bugzilla.suse.com/show_bug.cgi?id=1172898#c20.
