### PR TITLE
Save 1.5 MiB RAM by switching inst_setup to dash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ DESTDIR := images/instsys
 
 export ARCH THEMES DESTDIR INSTSYS_PARTS BOOT_PARTS WITH_FLOPPY BUILD_ID
 
-.PHONY: all dirs base fbase biostest initrd \
+.PHONY: all check dirs base fbase biostest initrd \
 	boot boot-efi root rescue root+rescue gdb libyui-rest-api bind libstoragemgmt clean \
 	boot-themes initrd-themes zenroot tftp install \
 	install-initrd mini-iso-rmlist debuginfo cd1 iso
@@ -172,7 +172,7 @@ rescue-server:
 	theme=$(THEMES) image=rescue-server src=rescue filelist=rescue-server fs=squashfs bin/mk_image
 
 root+rescue: base
-	# the next two lines just clean up old files
+	# the next two 'mk_image' runs just clean up old files
 	image=root+rescue fs=none bin/mk_image
 	image=root+initrd src=root+rescue fs=none filelist=root+rescue bin/mk_image
 	bin/common_tree --dst tmp/root+initrd tmp/initrd tmp/root
@@ -277,3 +277,11 @@ install-initrd:
 	  cp -a images/$$theme/install-initrd $(DESTDIR)/$$theme ; \
 	done
 
+# Catch bugs early
+# - make sure that the scripts run via dash don't end up with a bashism
+#
+# NOTE: as the current checks do not need the 'all' target,
+#       RPM spec calls this in %prep, before %build, to catch bugs early.
+#       Change .spec if 'check' needs 'all'
+check:
+	shellcheck data/root/etc/inst_setup data/root/etc/inst_setup_ssh

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 #
 
 #
@@ -22,14 +22,14 @@ chmod 755 /
 [ -e /proc/sys/vm/local-oom-kill ] && echo 1 > /proc/sys/vm/local-oom-kill
 
 if [ -f /.timestamp ] ; then
-  read build_time < /.timestamp
-  now_time=`TZ= LANG= LC_ALL= date +%Y%m%d`
+  read -r build_time < /.timestamp
+  now_time=$(TZ='' LANG='' LC_ALL='' date +%Y%m%d)
   if [ "$now_time" -lt "$build_time" ] ; then
        echo
        echo "your system time is not correct:"
-       TZ= date
+       TZ='' date
        echo "setting system time to:"
-       TZ= LANG= LC_ALL= date ${build_time#????*}1234${build_time%*????}.56
+       TZ='' LANG='' LC_ALL='' date "${build_time#????*}1234${build_time%*????}.56"
        echo
        /sbin/hwclock --systohc -u &
        sleep 3
@@ -49,14 +49,14 @@ exec < /dev/console > /dev/console 2>&1 3>&1
 
 yast="$1"
 shift
-echo $yast > /tmp/linuxrc_installer_name
+echo "$yast" > /tmp/linuxrc_installer_name
 export YAST2_SSH=false
 unset SSH_FAILED
 stty sane 2>/dev/null
 
 # get hostname & hostips
 hostip_from_wicked /tmp/host_ips /tmp/host_name
-host_name=`[ -f /tmp/host_name ] && cat /tmp/host_name`
+host_name=$([ -f /tmp/host_name ] && cat /tmp/host_name)
 
 #
 # a few files should be restored when installation has completed if we
@@ -145,6 +145,7 @@ done
 # boot with usessh=1 or use linuxrc to enable ssh 
 # vnc=1 will override the install mode
 if grep -q "^SSHD:.*1" /etc/install.inf ; then
+  # shellcheck source=data/root/etc/inst_setup_ssh
   test -x /sbin/inst_setup_ssh && . /sbin/inst_setup_ssh
 fi
 
@@ -212,6 +213,7 @@ EOF
   if [ -e /usr/lib/YaST2/startup/common/network.sh ] ; then
     echo "Active interfaces:"
 
+    # shellcheck disable=SC1091 # file in a different repo
     . /usr/lib/YaST2/startup/common/network.sh
     list_ifaces | head -n 20
   fi
@@ -259,6 +261,7 @@ done
 rm -f /etc/modules.conf
 
 # clean up after yast
+# shellcheck disable=SC2016 # the ${} is for sed, not a shell expansion mistake
 sed -n '1{h;n};x;H;${x;p}' /proc/mounts | awk '{ if($2 ~ /^\/var/) system("umount " $2) }'
 
 exit $ec

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -1,5 +1,4 @@
-#!/bin/bash
-#
+#!/bin/dash
 
 #
 # Note: linuxrc-based tools are in /lbin.
@@ -161,15 +160,16 @@ export EGL_LOG_LEVEL=fatal
 grep -qwi start_shell /proc/cmdline && START_SHELL=1
 grep -qi "^StartShell:.*1" /etc/install.inf && START_SHELL=1
 # leave a core file if yast crashes
+# shellcheck disable=SC2169 # "ulimit in dash may behave differently"; fine here
 ulimit -c unlimited
 
 # turn off plymouth splash screen
-function plymouth_off {
+plymouth_off() {
   [ -x /usr/bin/plymouth ] && plymouth quit
 }
 
 # start shell, useful on iSeries or via serial console
-function start_shell() {
+start_shell() {
   plymouth_off
   echo 
   echo "ATTENTION: Starting shell... (use 'exit' to proceed with installation)"
@@ -188,7 +188,7 @@ if grep -qi "^VNC:.*1" /etc/install.inf ; then
     (
     sleep 3
     /usr/bin/slptool register "service:YaST.installation.suse:vnc://${host_name}:5901"
-    ) &> /tmp/slptool_register.txt &
+    ) >/tmp/slptool_register.txt 2>&1 &
   else
     echo "slpd returned with exit code $ec, VNC will not be announced"
   fi
@@ -207,7 +207,7 @@ if [ "$YAST2_SSH" = "true" ] ; then
 
 EOF
   cp /etc/issue /etc/motd
-  echo -e "Run yast.ssh to start the installation.\n" >>/etc/motd
+  { echo "Run yast.ssh to start the installation."; echo; } >>/etc/motd
 
   # print more detailed list of ifaces using a function from yast2-installation
   if [ -e /usr/lib/YaST2/startup/common/network.sh ] ; then

--- a/data/root/etc/inst_setup_ssh
+++ b/data/root/etc/inst_setup_ssh
@@ -1,9 +1,10 @@
+#!/bin/bash
 # will be sourced by /sbin/inst_setup
 # but can also be called manually: $0 [-n] rootpassword
 
 # vim: syntax=sh
 
-if [ "$1" = "-h" -o "$1" = "--help" ] ; then
+if [ "$1" = "-h" ] || [ "$1" = "--help" ] ; then
   echo "Usage: setup_ssh [OPTIONS] [PASSWORD]"
   echo "Setup and run sshd."
   echo
@@ -16,7 +17,7 @@ if [ "$1" = "-h" -o "$1" = "--help" ] ; then
 fi
 
 nosshkey=false
-if [ "$1" = "-n" -o "$1" = "--no-sshkey" ] ; then
+if [ "$1" = "-n" ] || [ "$1" = "--no-sshkey" ] ; then
   nosshkey=true
   shift
 fi
@@ -25,7 +26,7 @@ if grep -qwi nosshkey < /proc/cmdline ; then
   nosshkey=true
 fi
 
-if ! test -z "$1" ; then
+if test -n "$1" ; then
   sshpassword=$1
 fi
 
@@ -37,7 +38,7 @@ if [ "$nosshkey" = "true" ] ; then
   chmod 600 /etc/ssh/*key
 fi
 
-if [ ! -z "$sshpassword" ] ; then
+if [ -n "$sshpassword" ] ; then
   echo "setting temporary root password to '$sshpassword'"
   echo "root:$sshpassword" | chpasswd
 fi

--- a/data/root/etc/inst_setup_ssh
+++ b/data/root/etc/inst_setup_ssh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/dash
 # will be sourced by /sbin/inst_setup
 # but can also be called manually: $0 [-n] rootpassword
 


### PR DESCRIPTION
`inst_setup` is a long lived program, a process ancestor of YaST, so it pays off to minimize its footprint: from 3360 KiB to 1788 KiB (-1572 KiB) measured by memsample (https://github.com/yast/yast-installation/pull/864)

### Dependencies

- [x] remove bashisms from `/usr/lib/YaST2/startup/common/network.sh`, sourced from here.
      Part of https://github.com/yast/yast-installation/pull/864 : https://github.com/yast/yast-installation/pull/864/commits/7ef133a43f46461fbf749b7c23dca8b294c84b87 (merged)

### Related: CI check? (→ yes, shellcheck)

I know of two tools to check shell scripts for Bash features or bugs: `shellcheck` and `checkbashisms`, and have used them on this PR.

It could be useful to run them in a CI test to detect accidental reintroduction of a bashism.

- `checkbashisms` is *small* (27KiB) and a bit hacky (Perl + regexes). It does not seem to have a 
way to ignore the harmless ocurrence of ulimit:
   > possible bashism in data/root/etc/inst_setup line 164 (ulimit):
   > ulimit -c unlimited
- `shellcheck` is *thorough*, detecting not only bashisms but also potential bugs around glob expansion and quoting, and having an explanation page for each of its diagnostics ([example](https://www.shellcheck.net/wiki/SC2039)). But it is big (17 MiB) and uses Haskell (could it be a problem with expanding the distro rebuild path?)

### Apply to more files? (→ not now)

This repo has many more shell scripts. We should identify those where it would pay off to switch from bash to dash.


