### PR TITLE
aarch64: add ipa kernel module

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -324,6 +324,7 @@ wicked:
 mdadm:
 multipath-tools:
 nfs-client:
+?system-group-wheel:
 
 ?openssh-fips:
 

--- a/etc/module.config
+++ b/etc/module.config
@@ -327,6 +327,7 @@ kernel/drivers/net/ethernet/.*
 kernel/drivers/net/fddi/.*
 kernel/drivers/net/hyperv/.*
 kernel/drivers/net/ieee802154/.*
+kernel/drivers/net/ipa/.*
 kernel/drivers/net/ipvlan/.*
 kernel/drivers/net/phy/.*
 kernel/drivers/net/team/.*


### PR DESCRIPTION
## Issues

- aarch64: add `ipa.ko` network module
- add `system-group-wheel` to rescue system

## Notes

-  `system-group-wheel` needs to be added explicitly at the right place due to dependency hell