### PR TITLE
generate hostnqn and hostid for NVMe (bsc#1172853)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -193,6 +193,7 @@ coreutils:
   /usr/bin/chmod
   /usr/bin/chown
   /usr/bin/cp
+  /usr/bin/cut
   /usr/bin/date
   /usr/bin/df
   /usr/bin/dirname

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -54,6 +54,12 @@ if [ -x /usr/sbin/wpa_supplicant ] ; then
   /usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -B -f /var/log/wpa_supplicant.log
 fi
 
+# create NVMe config files
+if [ -x /usr/sbin/nvme ] ; then
+  /usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn
+  cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
+fi
+
 if [ -x usr/sbin/wickedd ] ; then
   debug_opts="--debug mini --log-target stderr:time,pid,ident"
   if [ -n "$linuxrc_debug" ] ; then

--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -74,6 +74,10 @@ if [ -d /mounts/initrd/update ] ; then
   done
 fi
 
+# create NVMe config files
+nvme gen-hostnqn > /etc/nvme/hostnqn
+cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
+
 if [ "$startshell" = 1 ] ; then
   mount -t proc proc /proc
   echo "exit shell to continue startup process..."

--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -75,8 +75,10 @@ if [ -d /mounts/initrd/update ] ; then
 fi
 
 # create NVMe config files
+mount -t proc proc /proc
 nvme gen-hostnqn > /etc/nvme/hostnqn
 cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
+umount /proc
 
 if [ "$startshell" = 1 ] ; then
   mount -t proc proc /proc


### PR DESCRIPTION
Generate the hostnqn and hostid for NVMe in the installation and the rescue system.

For https://bugzilla.suse.com/show_bug.cgi?id=1172853.

Also see https://github.com/yast/yast-installation/pull/867 which implements copying hostnqn and hostid to the target system.

