### PR TITLE
libzypp wants to write to /var/lib/zypp (bsc#1172870)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -107,6 +107,7 @@ linuxrc:
 # add zypp config to initrd to ensure it's writable
 libzypp: nodeps
   /etc
+  /var/lib/zypp
   if patch_zypp_config_theme
     # patch /etc/zypp/zypp.conf (fate #321764); sets
     # solver.onlyRequires = true, rpm.install.excludedocs = yes, multiversion =


### PR DESCRIPTION
## Problem

- https://trello.com/c/RjeB1CJP

libzypp wants to write to `/var/lib/zypp`.

## Solution

Add the directory to initrd to ensure it is writable.