### PR TITLE
kmod-compat will be dropped

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -86,7 +86,8 @@ krb5:
 make:
 ?mkfontdir:
 mkfontscale:
-kmod-compat:
+kmod:
+?kmod-compat:
 openslp:
 p11-kit-tools:
 p11-kit:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -70,7 +70,8 @@ hwinfo:
 iputils:
 iscsiuio:
 kpartx:
-kmod-compat:
+kmod:
+?kmod-compat:
 krb5:
 lsscsi:
 mdadm:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -129,7 +129,8 @@ jfsutils:
 joe:
 ?kexec-tools:
 klogd:
-kmod-compat:
+kmod:
+?kmod-compat:
 kpartx:
 krb5:
 lsscsi:


### PR DESCRIPTION
## Problem

`kmod-compat` will be dropped (and merged into `kmod`).

## Solution

Make `kmod-compat` optional and use `kmod` instead.