### PR TITLE
Remove pycache to save space (20:4 MiB pre:post squashfs-ing)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -378,6 +378,7 @@ R s/ Server//g etc/issue
 # remove files we don't want to show up at all
 r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
 r dev/mapper dev/stderr dev/initctl
+e find . -name __pycache__ -print0 | xargs -0 rm -rf
 
 # remove grub2 *.module files, they're not needed
 # ... and strip *.mod files

--- a/data/root/bind.file_list
+++ b/data/root/bind.file_list
@@ -17,3 +17,4 @@ AUTODEPS:
 
 # remove files we don't want to show up at all
 r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
+e find . -name __pycache__ -print0 | xargs -0 rm -rf

--- a/data/root/libstoragemgmt.file_list
+++ b/data/root/libstoragemgmt.file_list
@@ -14,3 +14,4 @@ x libstoragemgmt.done .done
 
 # remove files we don't want to show up at all
 r /usr/share/{doc,info,locale,man} /usr/src/packages /usr/share/fillup-templates /var/adm/fillup-templates
+e find . -name __pycache__ -print0 | xargs -0 rm -rf

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -696,6 +696,7 @@ r /var/lib/systemd/migrated
 r /var/adm/autoinstall /var/lib/autoinstall
 e rm -f `find var/log -type f`
 e rm -f `find var/cache -type f`
+e find . -name __pycache__ -print0 | xargs -0 rm -rf
 
 # remove the Ruby gem cache files
 r /usr/lib*/ruby/gems/*/cache/*.gem


### PR DESCRIPTION
Related to:
- https://bugzilla.suse.com/show_bug.cgi?id=1172139
- https://trello.com/c/wnyocCGR/1961-5-reduce-installer-memory-needs-disk-files

Files in the [`__pycache__`][pyc] directories are compiled versions of the sources, used for faster loading. In the inst-sys, saving space is more important than the small speedup, so we delete them.

[pyc]: https://docs.python.org/3/tutorial/modules.html#compiled-python-files

### Size Before (Tumbleweed of 2020-07-04)

```console
$  wget https://download.opensuse.org/tumbleweed/repo/oss/boot/x86_64/{common,root}
(...)
$ du -hc common root
61M     common
73M     root
133M    total
$ pysize() { unsquashfs -ll $1 | grep __pycache__ | awk '{s += $3} END {print s/1024/1024}'; }
$ pysize common
18.8646
$ pysize root
0.151923
```

### Size After

```console
$ du -hc common root
57M     common
72M     root
129M    total
$ pysize root
0
$ pysize common
0
```