### PR TITLE
wicked started using /usr/libexec (bsc#1174957)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -72,7 +72,10 @@ if [ -x usr/sbin/wickedd ] ; then
   echo "Starting wicked"
   {
     /usr/sbin/wickedd $debug_opts
-    for i in /usr/lib/wicked/bin/wickedd-* ; do $i $debug_opts ; done
+    # latest wicked moved to /usr/libexec (bsc#1174957), support both locations
+    w_dir=/usr/libexec/wicked
+    [ -d $w_dir ] || w_dir=/usr/lib/wicked
+    for i in $w_dir/bin/wickedd-* ; do $i $debug_opts ; done
     /usr/sbin/wickedd-nanny $debug_opts
   } 2>/var/log/wickedd.log
 fi

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -34,6 +34,11 @@ TEMPLATE ruby.*-rubygem-suse-connect:
   # avoid update-alternatives
   e cd usr/bin ; ln -snf SUSEConnect* SUSEConnect
 
+TEMPLATE ruby.*-rubygem-nokogiri:
+  /
+  # avoid update-alternatives
+  e cd usr/bin ; find . -type l -name nokogiri\* -exec rm -f \{\} \; ; ln -snf nokogiri.ruby*-* nokogiri
+
 # fix the symlinks for the Ruby debugger if it is present
 TEMPLATE ruby.*-rubygem-byebug:
   /


### PR DESCRIPTION
## Issues

1. https://bugzilla.suse.com/show_bug.cgi?id=1174957
    - wicked started using `/usr/libexec` (instead of `/usr/lib`). Adjust to support both variants.
1. nokogiri uses update-alternatives, fix handling of these symlinks