### PR TITLE
use $releasever in repo URL (bsc#1171018)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -57,20 +57,21 @@ ExclusiveArch:  do_not_build
 %if 0%{?is_opensuse}
 %define theme openSUSE
 %if 0%{?sle_version}
-%define the_version %(echo %sle_version | sed -Ee 's/^([0-9][0-9])(0|([0-9]))([0-9]).*/\\1.\\3\\4/')
+# define the_version %(echo %sle_version | sed -Ee 's/^([0-9][0-9])(0|([0-9]))([0-9]).*/\\1.\\3\\4/')
+%define the_version \\$releasever
 %if "%{the_version}" == ""
 %error "bad version string"
 %endif
 %ifarch aarch64 ppc64 ppc64le
-%define net_repo http://download.opensuse.org/ports/%{the_arch}/distribution/leap/%{the_version}/repo/oss/
+%define net_repo https://download.opensuse.org/ports/%{the_arch}/distribution/leap/%{the_version}/repo/oss/
 %else
-%define net_repo http://download.opensuse.org/distribution/leap/%{the_version}/repo/oss
+%define net_repo https://download.opensuse.org/distribution/leap/%{the_version}/repo/oss
 %endif
 %else
 %ifarch aarch64 ppc64 ppc64le
-%define net_repo http://download.opensuse.org/ports/%{the_arch}/tumbleweed/repo/oss/
+%define net_repo https://download.opensuse.org/ports/%{the_arch}/tumbleweed/repo/oss/
 %else
-%define net_repo http://download.opensuse.org/tumbleweed/repo/oss
+%define net_repo https://download.opensuse.org/tumbleweed/repo/oss
 %endif
 %endif
 %endif


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1171018
- https://trello.com/c/Ze6ppnAz

Now that yast supports it, use `$releasever` in repo URL directly.

## Bonus

Change URLs to use https instead of http.