### PR TITLE
rename 'SUSE_MicroOS' to 'SUSE-MicroOS'

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -147,7 +147,7 @@ product_name      = openSUSE-Kubic
 [Theme SMO]
 image             = 350
 patch_zypp_config = 1
-release           = SUSE_MicroOS
+release           = SUSE-MicroOS
 skelcd            = SMO
 skelcd_ctrl       = SMO
 gfxboot           = SLE

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -914,7 +914,7 @@ sub get_version_info
 
   # don't accept other names than these
 
-  die "*** unsupported product: $dist ***" if $dist !~ /^(casp|caasp|kubic|microos|suse_microos|leap|sles|sled|tumbleweed( kubic)?)$/;
+  die "*** unsupported product: $dist ***" if $dist !~ /^(casp|caasp|kubic|microos|suse-microos|leap|sles|sled|tumbleweed( kubic)?)$/;
 
   # Kubic is based on TW
   # MicroOS can be based on TW or Leap

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -186,7 +186,7 @@ BuildRequires:  distribution-logos-openSUSE-Kubic
 %define branding_grub2    SLE
 %define branding_gfxboot  SLE
 %define config_bootmenu_no_upgrade 1
-BuildRequires:  SUSE_MicroOS-release
+BuildRequires:  SUSE-MicroOS-release
 %endif
 
 %if "%theme" == "MicroOS"


### PR DESCRIPTION
For consistency reason, changing underscore to dash everywhere