### PR TITLE
support exfat filesystem (bsc#1175731)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -105,6 +105,7 @@ dosfstools:
 ?dracut-fips:
 dump:
 e2fsprogs:
+exfatprogs:
 file-magic:
 file:
 fillup:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -134,6 +134,7 @@ cryptsetup:
 device-mapper:
 dosfstools:
 e2fsprogs:
+exfatprogs:
 file:
 fillup:
 findutils:

--- a/etc/module.config
+++ b/etc/module.config
@@ -404,6 +404,7 @@ MoreModules=fs-modules
 cifs,CIFS,-
 cramfs,CRAMFS,-
 exportfs,,-
+exfat,exFAT,-
 ext2,Ext2,-
 ext3,Ext3,-
 ext4,Ext4,-

--- a/etc/module.list
+++ b/etc/module.list
@@ -59,6 +59,7 @@ kernel/drivers/leds/led-class.ko
 kernel/drivers/mmc/core/
 kernel/fs/autofs4/
 kernel/fs/cramfs/
+kernel/fs/exfat/
 kernel/fs/ext2/
 kernel/fs/ext3/
 kernel/fs/ext4/


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1175731

Add support for exFAT filesystem:

- add exfatprogs package to installation and rescue system
- add exfat.ko kernel module