### PR TITLE
add watchdog modules (bsc#1176112)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -203,6 +203,7 @@ kernel/drivers/usb/common/usb-conn-gpio.ko
 kernel/drivers/usb/core/ledtrig-usbport.ko
 kernel/drivers/video/.*
 kernel/drivers/virtio/.*
+kernel/drivers/watchdog/.*
 kernel/drivers/xen/core/.*
 kernel/fs/nfs/.*,,-
 kernel/fs/nls/.*,,-

--- a/etc/module.list
+++ b/etc/module.list
@@ -245,6 +245,7 @@ kernel/drivers/pci/host/
 kernel/drivers/pci/controller/
 kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
+kernel/drivers/watchdog/
 
 kernel/fs/efivarfs/
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1176112

Watchdog might kick in and reset machine during installation beacuse it thinks it's hanging (i.e. the watchdog driver never gets loaded).

## Solution

Add kernel watchdog modules. This adds around 140 kB (compressed) to the initrd.

## See also

- same for `master`: https://github.com/openSUSE/installation-images/pull/413