### PR TITLE
fix library dependency checking

### DIFF
--- a/bin/check_libs
+++ b/bin/check_libs
@@ -48,7 +48,7 @@ while($dir = shift) {
 
   print "finding ELF objects...\n";
 
-  my $cmd = "cd $dir; find . -type f | grep -v modules | xargs file";
+  my $cmd = "cd $dir; find . -type f -o -type l | grep -v modules | xargs file -L";
   # for debugging a cache can be useful:
   # $cmd = "cat .found_files || ($cmd) | tee .found_files";
 


### PR DESCRIPTION
## Problem

If a library is a symlink to a different library (`libowcrypt` -> `libcrypt` in this case) the library dependency check did not work correctly.

## Solution

In case a library is a symlink to a lib with a different SONAME it is essential to also include the symlink in the elf object list.

The reason is that the library file name is also relevant for soname matching.