### PR TITLE
create /dev symlinks udev used to create (bsc#1176610)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -41,6 +41,13 @@ c 660 0 6 /dev/loop6
 b 7 7 /dev/loop7
 c 660 0 6 /dev/loop7
 
+# create these links udev used to create (bsc#1176610)
+s /proc/kcore /dev/core
+s /proc/self/fd /dev/fd
+s /proc/self/fd/0 /dev/stdin
+s /proc/self/fd/1 /dev/stdout
+s /proc/self/fd/2 /dev/stderr
+
 TEMPLATE dbus-1:
   /
   # not needed


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1176610

Latest udevd no longer creates some symlinks in `/dev`. For a list see above bug report.

This causes some programs to fail (like wicked, in the reported case).

## Solution

Add these symlinks at initrd build time.