### PR TITLE
really create /dev symlinks udevd used to create (bsc#1176610)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -41,13 +41,6 @@ c 660 0 6 /dev/loop6
 b 7 7 /dev/loop7
 c 660 0 6 /dev/loop7
 
-# create these links udev used to create (bsc#1176610)
-s /proc/kcore /dev/core
-s /proc/self/fd /dev/fd
-s /proc/self/fd/0 /dev/stdin
-s /proc/self/fd/1 /dev/stdout
-s /proc/self/fd/2 /dev/stderr
-
 TEMPLATE dbus-1:
   /
   # not needed

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -4,6 +4,13 @@ exec >&2
 
 PATH="/sbin:/bin:/usr/bin:/usr/sbin:/lbin"
 
+# create these links udevd used to create (bsc#1176610)
+ln -snf /proc/kcore /dev/core
+ln -snf /proc/self/fd /dev/fd
+ln -snf /proc/self/fd/0 /dev/stdin
+ln -snf /proc/self/fd/1 /dev/stdout
+ln -snf /proc/self/fd/2 /dev/stderr
+
 # load some modules before udevd
 for i in edd scsi_dh_alua scsi_dh_emc scsi_dh_rdac ; do
   [ -f /modules/$i.ko -o -f /modules/$i.ko.xz ] && modprobe $i


### PR DESCRIPTION
## Problem

https://github.com/openSUSE/installation-images/pull/418 does not work.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1176610

Latest udevd no longer creates some symlinks in `/dev`. For a list see above bug report.

This causes some programs to fail (like wicked, in the reported case).

## Solution

Create the links right before udevd is started. Doing it earlier is no use as linuxrc mounts devtmpfs just before running the `udev_setup` script. Any earlier adjustments are lost.