### PR TITLE
plymouthd.defaults will be moved to branding package (jsc#SLE-11637)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -366,10 +366,12 @@ pam:
 if exists(plymouth)
   plymouth:
     /
-    R s/^Theme=.*/Theme=tribar/ /usr/share/plymouth/plymouthd.defaults
   plymouth-scripts: nodeps
   plymouth-plugin-script:
   plymouth-branding-<plymouth_theme>: nodeps
+    /
+    e cp usr/share/plymouth/plymouthd.defaults etc/plymouth/plymouthd.conf
+    R s/^Theme=.*/Theme=tribar/ /etc/plymouth/plymouthd.conf
   ?plymouth-theme-tribar:
 endif
 


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/SLE-11637

`plymouthd.defaults` moves into branding package.

## See also

- https://github.com/openSUSE/installation-images/pull/420