### PR TITLE
prevent cross-filesystem relative symlinks to kmod in initrd (bsc#1169094)

### DIFF
--- a/gefrickel
+++ b/gefrickel
@@ -61,7 +61,10 @@ for i in usr/$lib_dir/lib* ; do
   case $i in *librpm*) continue ;; esac
   mv $i b/usr/$lib_dir
 done
-mkdir -p b/usr/bin
+
+# empty usr/sbin is needed to avoid bsc#1169094 (cross-filesystem relative
+# symlinks to kmod)
+mkdir -p b/usr/bin b/usr/sbin
 # some things are needed from /usr/bin
 for i in kmod bash mount setsid sh; do
   [ -e usr/bin/$i -o -L usr/bin/$i ] && mv usr/bin/$i b/usr/bin


### PR DESCRIPTION
## Problem

In initrd, `/usr/sbin/modprobe` (with full path) does not work because `/usr/sbin/modprobe` is a symlink to `../bin/kmod` but `kmod` is on a different file system and the symlink resolution ends up at the wrong spot.

## Solution

Add an empty `/usr/sbin` dir to the initrd.

## Explanation

To illustrate the problem, here is the situation before and after the patch.

- before

```sh
tty9:install:/ # ls -ld /usr/sbin
lrwxrwxrwx 1 root root 23 Sep 23 08:04 /usr/sbin -> /parts/mp_0001/usr/sbin
tty9:install:/ # ls -l /usr/sbin/modprobe
lrwxrwxrwx 1 root root 11 Aug  2 00:00 /usr/sbin/modprobe -> ../bin/kmod
tty9:install:/ # ls -l /usr/bin/kmod
-rwxr-xr-x 1 root root 162040 Jul 29 15:28 /usr/bin/kmod
tty9:install:/ # ls -l /parts/mp_0001/usr/bin/kmod
ls: cannot access '/parts/mp_0001/usr/bin/kmod': No such file or directory
tty9:install:/ # /usr/sbin/modprobe
sh: /usr/sbin/modprobe: No such file or directory
```

- after

```sh
tty9:install:/ # ls -ld /usr/sbin
drwxr-xr-x 2 root root 2460 Sep 23 08:14 /usr/sbin
tty9:install:/ # ls -l /usr/sbin/modprobe
lrwxrwxrwx 1 root root 11 Sep 23 08:14 /usr/sbin/modprobe -> ../bin/kmod
tty9:install:/ # ls -l /usr/bin/kmod
-rwxr-xr-x 1 root root 162040 Aug 25 12:13 /usr/bin/kmod
tty9:install:/ # /usr/sbin/modprobe
modprobe: ERROR: missing parameters. See -h.
```