### PR TITLE
adjust to openssh package split

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -452,9 +452,13 @@ dbus-1:
 
 ?libopenssl*_*-hmac:
 
-openssh: nodeps
-  E prein
-  d etc/ssh
+if exists(openssh-server)
+  openssh-server: nodeps
+else
+  openssh: nodeps
+endif
+    E prein
+    d etc/ssh
 
 system-group-hardware:
   /

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -330,12 +330,17 @@ nfs-client:
 
 ?openssh-fips:
 
-openssh:
-  /
-  E prein
-  E postin
-  # enable root login bsc#1118114
-  R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
+if exists(openssh-server)
+  openssh:
+  openssh-server:
+else
+  openssh:
+endif
+    /
+    E prein
+    E postin
+    # enable root login bsc#1118114
+    R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
 
 ?ia32el:
   /etc/init.d/ia32el

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -655,12 +655,17 @@ endif
 
 ?openssh-fips:
 
-openssh:
-  /
-  t /etc/sysconfig/ssh
-  E prein
-  # enable root login bsc#1118114
-  R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
+if exists(openssh-server)
+  openssh:
+  openssh-server:
+else
+  openssh:
+endif
+    /
+    t /etc/sysconfig/ssh
+    E prein
+    # enable root login bsc#1118114
+    R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
 
 fonts-config:
   /


### PR DESCRIPTION
## Task

openssh has been split into openssh-{common,clients,server}. Pre-scripts for user & group id creation are in openssh-server. openssh is now a meta package requiring openssh-clients and openssh-server.

The patch works with the old and new package layouts.