### PR TITLE
include all of xorg-x11-server

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -454,9 +454,7 @@ endif
 
 if arch ne 's390' && arch ne 's390x'
   xorg-x11-server:
-    /etc/X11/xorg.conf.d
-    /usr/bin/Xorg
-    /usr/<lib>/xorg/modules
+    /
     # avoid update-alternatives
     e [ -f usr/<lib>/xorg/modules/extensions/xorg/xorg-libglx.so ] && ln -snf xorg/xorg-libglx.so usr/<lib>/xorg/modules/extensions/libglx.so ; true
 


### PR DESCRIPTION
## Problem

Latest xorg-x11-server package has split the `Xorg` binary into `Xorg` and `Xorg.bin`. To simplify things include the whole package. The additional space is negligible (basically the `cvt` and `gtf` binaries).