### PR TITLE
don't forget .lib*.hmac files (bsc#1178208)

### DIFF
--- a/gefrickel
+++ b/gefrickel
@@ -57,9 +57,10 @@ rm -rf a b
 # keep libs for linuxrc
 #
 mkdir -p "b/usr/$lib_dir"
-for i in usr/$lib_dir/lib* ; do
+# don't forget .lib*.hmac files (bsc#1178208)
+for i in usr/$lib_dir/lib* usr/$lib_dir/.lib* ; do
   case $i in *librpm*) continue ;; esac
-  mv $i b/usr/$lib_dir
+  [ -e "$i" ] && mv $i b/usr/$lib_dir
 done
 
 # empty usr/sbin is needed to avoid bsc#1169094 (cross-filesystem relative


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1178208

`libcrypto.so` is not working (needed in `insmod`) because its corresponding `*.hmac` file is not available as it's sitting on a separate filesystem for which an `insmod` is needed to mount it...

## Solution

When separating out the early initrd part, don't forget to move `*.hmac` files along with the libraries.