### PR TITLE
etc: update module.config to match 5.10

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -147,6 +147,7 @@ dns_resolver
 rapidio
 ntb
 ntb_netdev
+nfs_ssc
 nfsd
 grace
 
@@ -330,6 +331,8 @@ kernel/drivers/net/hyperv/.*
 kernel/drivers/net/ieee802154/.*
 kernel/drivers/net/ipa/.*
 kernel/drivers/net/ipvlan/.*
+kernel/drivers/net/mdio/.*
+kernel/drivers/net/pcs/.*
 kernel/drivers/net/phy/.*
 kernel/drivers/net/team/.*
 kernel/drivers/net/tokenring/.*


### PR DESCRIPTION
5.10 moved some `net/phy` drivers to `net/mdio` and `net/pcs`. Adapt to that
change.

Since 5.10 (and 5.9.2 too), `nfs_ssc` is now enabled in our kernels as
`nfsd` always needed it. So move it along to `nfsd`.