### PR TITLE
add system-group-kvm explicitly

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -282,6 +282,7 @@ s /usr/bin/true /sbin/mkinitrd_setup
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 system-group-hardware:
+system-group-kvm:
 system-user-nobody:
 
 rpm:


### PR DESCRIPTION
## Task

The system-group-kvm package is required by udev now but would be auto-added too early for its preinstall script to run.

To avoid this, add it explicitly at a better (later) place.