### PR TITLE
revert plymouth branding for SLE to tribar

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -370,8 +370,15 @@ if exists(plymouth)
   plymouth-branding-<plymouth_theme>: nodeps
     /
     e cp usr/share/plymouth/plymouthd.defaults etc/plymouth/plymouthd.conf
-    R s/^Theme=.*/Theme=bgrt/ /etc/plymouth/plymouthd.conf
-  ?plymouth-theme-bgrt:
+  if exists(plymouth-theme-tribar)
+    plymouth-theme-tribar:
+      /
+      R s/^Theme=.*/Theme=tribar/ /etc/plymouth/plymouthd.conf
+  elsif exists(plymouth-theme-bgrt)
+    plymouth-theme-bgrt:
+      /
+      R s/^Theme=.*/Theme=bgrt/ /etc/plymouth/plymouthd.conf
+  endif
 endif
 
 procps:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -437,13 +437,6 @@ BuildRequires:  perl-XML-Parser
 BuildRequires:  perl-XML-Simple
 BuildRequires:  perl-solv
 BuildRequires:  pinentry
-# SLE lacks bgrt/spinner branding image and doesn't require bgrt theme
-# in their branding, so using default bgrt theme package
-%if 0%{?is_opensuse}
-BuildRequires:  plymouth-branding-openSUSE
-%else
-BuildRequires:  plymouth-theme-bgrt
-%endif
 BuildRequires:  python3-websockify
 BuildRequires:  raleway-fonts
 BuildRequires:  samba
@@ -463,6 +456,12 @@ BuildRequires:  plymouth
 BuildRequires:  plymouth-branding
 BuildRequires:  plymouth-plugin-script
 BuildRequires:  plymouth-scripts
+# SLE needs to stay with tribar
+%if 0%{?is_opensuse}
+BuildRequires:  plymouth-branding-openSUSE
+%else
+BuildRequires:  plymouth-theme-tribar
+%endif
 %endif
 BuildRequires:  klogd
 BuildRequires:  ltrace


### PR DESCRIPTION
## Task

The recent plymouth branding switch is unwanted for SLE. See https://github.com/openSUSE/installation-images/pull/442.