### PR TITLE
do not run prein script for openssh-server in root image

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -653,7 +653,6 @@ else
 endif
     /
     t /etc/sysconfig/ssh
-    E prein
     # enable root login bsc#1118114
     R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
 


### PR DESCRIPTION
## Background

openssh-server runs useradd in its prein script. The script used to ignore errors in the past while now it returns an error code.

## Problem

installation-images runs the prein script when building the `root` image. But that's a mistake as it is not needed here because passwd and group files are in the initrd (and openssh-server's prein is run there).

## Solution

Do not run prein script here.