### PR TITLE
work around broken plymouth (bsc#1149070)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -169,6 +169,7 @@ plymouth_off() {
 # start shell, useful on iSeries or via serial console
 start_shell() {
   plymouth_off
+  echo -n \\033c
   echo 
   echo "ATTENTION: Starting shell... (use 'exit' to proceed with installation)"
   bash -l


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1181467
- https://openqa.opensuse.org/tests/1599436#step/setup_libyui/4
- https://build.opensuse.org/request/show/866061

plymouth doesn't restore the console properly when it is turned off.
<details>
<summary>See this example</summary>

![foo](https://user-images.githubusercontent.com/927244/106002451-739bcb80-60b1-11eb-9b40-f849694b8456.jpg)

</details>

## Workaround

At least for the `startshell` boot option: clear console before starting the shell.

Note this is only a workaround until [bsc#1181467](https://bugzilla.suse.com/show_bug.cgi?id=1181467) gets fixed.