### PR TITLE
aarch64: add tegra20-apb-dma module (bsc#1181463)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -175,6 +175,8 @@ virtio_net
 net_failover
 virtio_scsi
 
+tegra20-apb-dma
+
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-
 kernel/crypto/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -252,6 +252,7 @@ kernel/drivers/watchdog/
 kernel/fs/efivarfs/
 
 kernel/drivers/dma/bcm2835-dma.ko
+kernel/drivers/dma/tegra20-apb-dma.ko
 
 kernel/fs/vboxsf/
 kernel/drivers/virt/vboxguest/


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1181463

Add `tegra20-apb-dma` module explicitly.