### PR TITLE
etc: update module.config to match 5.11 (bsc#1182301)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -77,6 +77,7 @@ loop_fish2
 lp
 lvm-mod
 mc13783-core
+mhi_net
 ncpfs
 netconsole,Console driver for network interfaces
 nfs_acl,-,-
@@ -130,6 +131,7 @@ ptp_clockmatrix
 ptp_dte
 ptp_idt82p33
 ptp_kvm
+ptp_ocp
 ptp_pch
 ptp_qoriq
 ptp_vmw


### PR DESCRIPTION
5.11 brought two new modules:
* ptp_ocp -- add it along other ptps
* mhi_net -- special wwan modems, placed into other