### PR TITLE
Replace Raleway fonts by Poppins

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -563,7 +563,7 @@ efont-unicode-bitmap-fonts:
 
 ?noto-sans-fonts:
 
-?raleway-fonts:
+?google-poppins-fonts:
 
 # various asiatic & arabic fonts
 indic-fonts:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -438,7 +438,7 @@ BuildRequires:  perl-XML-Simple
 BuildRequires:  perl-solv
 BuildRequires:  pinentry
 BuildRequires:  python3-websockify
-BuildRequires:  raleway-fonts
+BuildRequires:  google-poppins-fonts
 BuildRequires:  samba
 BuildRequires:  snapper
 BuildRequires:  suse-module-tools


### PR DESCRIPTION
### Problem

New SLE branding uses *google-poppins-fonts* instead of *Raleway*, see https://github.com/yast/yast-theme/pull/132.

* https://jira.suse.com/browse/SLE-15714

### Solution

Provide expected fonts. Note that *google-poppins-fonts* is already included in SLE-15-SP3 project, see https://build.suse.de/package/show/SUSE:SLE-15-SP3:GA/google-poppins-fonts.
