### PR TITLE
Add kernel modules necessary for Raspberry Pi 4 (bsc#1180336)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -618,6 +618,14 @@ af_iucv
 kernel/drivers/s390/.*
 kernel/arch/s390/.*
 
+reset-raspberrypi
+clk-raspberrypi
+raspberrypi-cpufreq
+cpufreq-dt
+sdhci
+sdhci-iproc
+gpio-raspberrypi-exp
+mdio-bcm-unimac
 
 ; modules we do _not_ need
 [notuseful]

--- a/etc/module.list
+++ b/etc/module.list
@@ -257,6 +257,15 @@ kernel/drivers/dma/tegra20-apb-dma.ko
 kernel/fs/vboxsf/
 kernel/drivers/virt/vboxguest/
 
+# RPi4
+kernel/drivers/reset/reset-raspberrypi.ko
+kernel/drivers/clk/bcm/clk-raspberrypi.ko
+kernel/drivers/cpufreq/raspberrypi-cpufreq.ko
+kernel/drivers/cpufreq/cpufreq-dt.ko
+kernel/drivers/mmc/host/sdhci-iproc.ko
+kernel/drivers/gpio/gpio-raspberrypi-exp.ko
+kernel/drivers/net/mdio/mdio-bcm-unimac.ko
+
 # kmps
 updates/
 


### PR DESCRIPTION
Reference: bsc#1180336
Signed-off-by: Nicolas Saenz Julienne <nsaenzjulienne@suse.de>