### PR TITLE
spec: no longer have ports project for Leap since 15.3

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -63,11 +63,7 @@ ExclusiveArch:  do_not_build
 %if "%{the_version}" == ""
 %error "bad version string"
 %endif
-%ifarch %arm aarch64 ppc64 ppc64le
-%define net_repo https://download.opensuse.org/ports/%{the_arch}/distribution/leap/%{the_version}/repo/oss/
-%else
 %define net_repo https://download.opensuse.org/distribution/leap/%{the_version}/repo/oss
-%endif
 %else
 %define with_exfat 1
 %ifarch %arm aarch64 ppc64 ppc64le


### PR DESCRIPTION
Starting with Leap 15.3, Leap doesn't have *ports* project anymore, net repo is at a unified location for all supported architectures.