### PR TITLE
allow wildcards in modinfo firmware names (bsc#1180336)

### DIFF
--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -25,17 +25,15 @@ close F;
 
 for $m (sort keys %fw) {
   for $fw (@{$fw{$m}}) {
-    $f = undef;
-    $f = "$fw" if -f "$fw_dir/$fw";
-    $f = "$kv/$fw" if -f "$fw_dir/$kv/$fw";
-
-    if($f) {
-      system "install -m 644 -D $fw_dir/$f lib/firmware/$f\n";
+    my $ok = 0;
+    for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw>) {
+      if(-r $f) {
+        $f =~ s#^$fw_dir/##;
+        system "install -m 644 -D $fw_dir/$f lib/firmware/$f\n";
+        $ok = 1;
+      }
     }
-    else {
-      $err = 1;
-      print "missing firmware: $fw ($m.ko)\n";
-    }
+    print "missing firmware: $fw ($m.ko)\n" if !$ok;
   }
 }
 


### PR DESCRIPTION
## Task

The kernel firmware files to include in the initrd are calculated from module dependencies.

Upcoming kernels can have shell wildcards in `firmware` fields in modinfo, like

```
# modinfo brcmfmac.ko.xz
filename:       brcmfmac.ko.xz
license:        Dual BSD/GPL
description:    Broadcom 802.11 wireless LAN fullmac driver.
author:         Broadcom Corporation
firmware:       brcm/brcm/brcmfmac*-pcie.*.txt
firmware:       brcm/brcm/brcmfmac*-sdio.*.txt
firmware:       brcm/brcmfmac43012-sdio.bin
...
```

Adjust script to take this into account.

## See also

- https://github.com/openSUSE/installation-images/pull/453
