### PR TITLE
fix kernel & initrd location for x86_64 (bsc#1182239)

### DIFF
--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -20,6 +20,11 @@ shim_dir = usr/share/efi/<arch>
 x grub-efi.cfg EFI/BOOT/grub.cfg
 R s/\@arch\@/<arch>/g EFI/BOOT/grub.cfg
 
+# kernel & initrd are in a different dir on x86_64
+if arch eq 'x86_64'
+  R s/(\/(linux|initrd))/\/loader$1/g EFI/BOOT/grub.cfg
+endif
+
 # keep everything between <foo>...</foo> when foo == arch and drop everything between <foo>...</foo> when foo != arch
 #
 # <foo> and </foo> must be alone on separate lines


### PR DESCRIPTION
## Issue

Kernel and initrd are in `/boot/x86_64/loader`, not `/boot/x86_64` on x86_64. Adjust EFI grub config.