### PR TITLE
fix adapting grub.cfg for different architectures (bsc#1182593)

### DIFF
--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -30,7 +30,7 @@ endif
 # <foo> and </foo> must be alone on separate lines
 #
 R s/<\/?<arch>>\n// EFI/BOOT/grub.cfg
-R s/<([a-z_0-9]+)>.*?<\/\1>\n//s EFI/BOOT/grub.cfg
+R s/<([a-z_0-9]+)>.*?<\/\1>\n//sg EFI/BOOT/grub.cfg
 
 grub2-<grub_target>-efi:
   a <grub_efi> EFI/BOOT/boot<boot_efi>.efi

--- a/lib/AddFiles.pm
+++ b/lib/AddFiles.pm
@@ -810,7 +810,7 @@ sub _add_pack
       close F1;
       SUSystem "rm -f $tfile";
 
-      if($re =~ /\/s; 1$/) {	# multi line
+      if($re =~ /\/sg?; 1$/) {	# multi line
         $_ = join '', @f;
         $ignore += 10;
         $i = eval $re;


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1182593

Architecture dependent parts in `grub.cfg` (XML-like enclosed by `<ARCH>...</ARCH>`) were not handled correctly. Only the first non-matching blob was removed.