### PR TITLE
go back to plymouth-theme-tribar (bsc#1182755)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -363,6 +363,16 @@ pam:
   /lib*/security/pam_deny.so
 
 if exists(plymouth)
+  # Do not EVER consider another plymouth theme before ensuring it doesn't
+  # drag in tons of weird dependencies (bsc#1182755).
+  if exists(plymouth-theme-tribar)
+    p_theme = tribar
+  # elsif exists(plymouth-theme-XXX)
+  #  p_theme = XXX
+  else
+    p_theme = PLYMOUTH_THEME_IS_MISSING
+  endif
+
   plymouth:
     /
   plymouth-scripts: nodeps
@@ -370,15 +380,9 @@ if exists(plymouth)
   plymouth-branding-<plymouth_theme>: nodeps
     /
     e cp usr/share/plymouth/plymouthd.defaults etc/plymouth/plymouthd.conf
-  if exists(plymouth-theme-tribar)
-    plymouth-theme-tribar:
-      /
-      R s/^Theme=.*/Theme=tribar/ /etc/plymouth/plymouthd.conf
-  elsif exists(plymouth-theme-bgrt)
-    plymouth-theme-bgrt:
-      /
-      R s/^Theme=.*/Theme=bgrt/ /etc/plymouth/plymouthd.conf
-  endif
+  plymouth-theme-<p_theme>:
+    /
+    R s/^Theme=.*/Theme=<p_theme>/ /etc/plymouth/plymouthd.conf
 endif
 
 procps:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -456,12 +456,7 @@ BuildRequires:  plymouth
 BuildRequires:  plymouth-branding
 BuildRequires:  plymouth-plugin-script
 BuildRequires:  plymouth-scripts
-# SLE needs to stay with tribar
-%if 0%{?is_opensuse}
-BuildRequires:  plymouth-branding-openSUSE
-%else
 BuildRequires:  plymouth-theme-tribar
-%endif
 %endif
 BuildRequires:  klogd
 BuildRequires:  ltrace


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1182755

`plymouth-theme-bgrt` requires `plymouth-plugin-label` which (citing its rpm description): *'provides the ability to render text on graphical boot splashes using pango and cairo'*.

So this adds the whole X and cairo font rendering stack to the initrd, which is roughly about 5 MB compressed. Just to show some text.

**Thank you.**

`tribar` can display text on a text console the normal way.

## Solution

Revert to using `plymouth-theme-tribar` and add comment to sources to warn future generations about this. 