### PR TITLE
support using zram device as root file system (jsc#PM-2253)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -436,6 +436,9 @@ endif
   /usr/lib*/gconv/UTF-32.so
   /usr/lib*/gconv/gconv-modules*
 
+# needed for zram support
+e2fsprogs:
+  /usr/sbin/mkfs.ext2
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #

--- a/data/initrd/scripts/zram_setup
+++ b/data/initrd/scripts/zram_setup
@@ -1,0 +1,17 @@
+#! /bin/sh
+
+# zram size is passed as first argument
+size=$1
+
+PATH=/usr/bin:/usr/sbin:/bin:/sbin
+
+# no modprobe
+for i in zram jbd2 mbcache crc16 ext4 ; do
+  m=/modules/$i.ko.xz
+  [ -f $m ] && insmod $m
+done
+
+echo zstd > /sys/block/zram0/comp_algorithm
+echo $size > /sys/block/zram0/disksize
+
+mkfs.ext2 -q /dev/zram0

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -175,6 +175,48 @@ start_shell() {
   bash -l
 }
 
+zram_swap_on() {
+  zram_swap=`awk '/^zram_swap:/ { print $2 }' /etc/install.inf`
+  if [ -n "$zram_swap" ] ; then
+    modprobe zram
+    zram_dev_index=`cat /sys/class/zram-control/hot_add`
+    zram_swap_dev=/dev/zram$zram_dev_index
+    if [ -b $zram_swap_dev ] ; then
+      echo zstd > /sys/block/zram$zram_dev_index/comp_algorithm
+      echo "$zram_swap" > /sys/block/zram$zram_dev_index/disksize
+      mkswap $zram_swap_dev >/dev/null
+      swapon $zram_swap_dev
+      create_zram_swap_disable_hook
+    fi
+  fi
+}
+
+zram_swap_off() {
+  if [ -b $zram_swap_dev ] ; then
+    swapoff $zram_swap_dev
+    echo $zram_dev_index > /sys/class/zram-control/hot_remove
+  fi
+}
+
+create_zram_swap_disable_hook() {
+  tmp_dir=$(mktemp -d)
+  hook_dir=/var/lib/YaST2/hooks/installation
+  script=before_instsys_cleanup_10_zram_swap
+
+  # make $hook_dir writable
+  mkdir -p $tmp_dir/$hook_dir
+  adddir $tmp_dir /
+
+  cat > $hook_dir/$script <<XXX
+#! /bin/sh -x
+swapoff $zram_swap_dev
+echo $zram_dev_index > /sys/class/zram-control/hot_remove
+XXX
+  chmod +x $hook_dir/$script
+}
+
+zram_swap_on
+
 [ -f /tmp/host_ips ] && cat /tmp/host_ips
 
 [ "$START_SHELL" ] && start_shell
@@ -262,6 +304,8 @@ rm -f /etc/modules.conf
 # clean up after yast
 # shellcheck disable=SC2016 # the ${} is for sed, not a shell expansion mistake
 sed -n '1{h;n};x;H;${x;p}' /proc/mounts | awk '{ if($2 ~ /^\/var/) system("umount " $2) }'
+
+zram_swap_off
 
 exit $ec
 

--- a/gefrickel
+++ b/gefrickel
@@ -35,10 +35,12 @@ lib_dir=${lib_dir%%/*}
 #
 # all mods ex loop & squashfs
 #
+base_modules="loop squashfs lz4_decompress xxhash zstd_decompress zram ext4 crc16 mbcache jbd2"
+echo "$base_modules" > .base_modules
 m_dir=`echo lib/modules/*/initrd`
 [ -d "$m_dir" ] || err "no kernel module dir"
 mkdir -p "b/$m_dir"
-for i in loop squashfs lz4_decompress xxhash zstd_decompress; do
+for i in $base_modules ; do
   for suffix in ko ko.xz; do
     [ -f $m_dir/$i.$suffix ] && mv $m_dir/$i.$suffix b/$m_dir
   done
@@ -67,8 +69,12 @@ done
 # symlinks to kmod)
 mkdir -p b/usr/bin b/usr/sbin
 # some things are needed from /usr/bin
-for i in kmod bash mount setsid sh; do
+for i in kmod bash mount setsid sh ; do
   [ -e usr/bin/$i -o -L usr/bin/$i ] && mv usr/bin/$i b/usr/bin
+done
+# some things are needed from /usr/sbin
+for i in mkfs.ext2 ; do
+  [ -e usr/sbin/$i -o -L usr/sbin/$i ] && mv usr/sbin/$i b/usr/sbin
 done
 mkdir -p a
 mv usr a


### PR DESCRIPTION
## Task

Allow moving the root file system into a zram device and/or enable swapping to a zram device.

- https://jira.suse.com/browse/PM-2253
- https://trello.com/c/DawiPzcU

## See also

- related linuxrc change, needed to eable this feature: https://github.com/openSUSE/linuxrc/pull/246
- zram documentation: https://www.kernel.org/doc/html/latest/admin-guide/blockdev/zram.html

## Notes

- this just adds the necessary infrastructure, it does not enable this feature
- the changes do not affect the non-zram workflow
- ext2 is used for the root fs, it  has slightly less meta data and tooling overhead than xfs
- zstd compression is used
- if swap into zram is requested, the zram swap device is removed after yast has enabled a 'real' swap device (after the disk preparation stage)
- for usage instructions, check the referenced linuxrc pull request