### PR TITLE
Add susepaste to the rescue system (bsc#1182212)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -163,6 +163,7 @@ squashfs:
 star:
 strace:
 suse-module-tools:
+susepaste:
 sysconfig:
 sysconfig-netconfig:
 systemd-presets-branding-<systemd_theme>:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -177,6 +177,7 @@ sed:
 sg3_utils:
 snapper:
 suse-module-tools:
+susepaste:
 ?syslinux:
 systemd-presets-branding-<systemd_theme>:
 systemd-sysvinit:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -442,6 +442,7 @@ BuildRequires:  google-poppins-fonts
 BuildRequires:  samba
 BuildRequires:  snapper
 BuildRequires:  suse-module-tools
+BuildRequires:  susepaste
 BuildRequires:  systemd
 BuildRequires:  systemd-presets-branding
 BuildRequires:  sysvinit-tools


### PR DESCRIPTION
See [bsc#1182212](https://bugzilla.suse.com/show_bug.cgi?id=1182212) which reads: "_Forum posters are often requested to supply additional information by those trying to help solve their problems. Availability of susepaste would facilitate collection of much of that information from those unfamiliar with shell prompts_".

I hope this would be enough to address that, but @wfeldt will know better.