### PR TITLE
fix efi local boot entry on x86_64 (bsc#1182891)

### DIFF
--- a/data/boot/grub-efi.cfg
+++ b/data/boot/grub-efi.cfg
@@ -44,6 +44,7 @@ menuentry "Boot from Hard Disk" --class opensuse --class gnu-linux --class gnu -
     for os in opensuse sles caasp ; do
       if [ -f /efi/$os/grub.efi ] ; then
         chainloader /efi/$os/grub.efi
+        boot
       fi
     done
   fi


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1182891

The EFI local boot entry does not work on x86_64. Instead of booting from local disk it just exits grub.

## Solution

Add missing `boot` command.