### PR TITLE
disable zram swap only if there's another swap active (bsc#1183276)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -209,8 +209,12 @@ create_zram_swap_disable_hook() {
 
   cat > $hook_dir/$script <<XXX
 #! /bin/sh -x
-swapoff $zram_swap_dev
-echo $zram_dev_index > /sys/class/zram-control/hot_remove
+
+# at least 2 swap devices
+if [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
+  swapoff $zram_swap_dev
+  echo $zram_dev_index > /sys/class/zram-control/hot_remove
+fi
 XXX
   chmod +x $hook_dir/$script
 }


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1183276

zram swap is disabled after partitioning the disk, assuming there's some other swap space active at that point.

This might not be the case.

## Solution

Add check to ensure zram swap is disabled only if there is another swap device active.

## See also

- original implementation: https://github.com/openSUSE/installation-images/pull/462