### PR TITLE
ensure base modules are loaded before starting the rescue system (bsc#1183388)

### DIFF
--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -74,6 +74,12 @@ if [ -d /mounts/initrd/update ] ; then
   done
 fi
 
+# ensure all base modules are loaded - they will not be available in the
+# rescue system (bsc#1183388)
+for i in $(cat /mounts/initrd/.base_modules) ; do
+  modprobe -q -d /mounts/initrd $i
+done
+
 # create NVMe config files
 mount -t proc proc /proc
 nvme gen-hostnqn > /etc/nvme/hostnqn


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1183388

It's not possible to mount an ext2 file system in the rescue system if `zram=0` (the default) is used.

## Analysis

linuxrc needs a small number of modules (let's call them base modules) to bootstrap things. For example, `loop` and `squashfs` are needed to even mount the squashfs image containing all other kernel modules. Since zram support was added, `ext4` became also a base module (since ext2 is used as the root filesystem).

But base modules are not added to the rescue system (only the image with the regular modules is) - as it is assumed they have already been loaded anyway. Which is not true for `ext4` if zram support is **not** used.

## Solution

When starting the rescue system ensure all base modules are loaded. A list of these modules is kept in `/.base_modules` in the initrd.