### PR TITLE
handle update-alternative symlinks automatically

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -66,12 +66,10 @@ TEMPLATE:
 
 AUTODEPS:
 
-# it's using update-alternatives
 # XXX: usrmerge
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
-  s bash usr/bin/sh
 
 binutils: ignore
 ca-certificates-mozilla:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -245,12 +245,10 @@ coreutils:
   # linuxrc needs it in /bin
   m /usr/bin/rm bin
 
-# it's using update-alternatives
 # XXX: usrmerge
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
-  s bash usr/bin/sh
   s bash usr/bin/lsh
 
 ncurses-utils:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -74,7 +74,6 @@ update-alternatives: ignore
 device-mapper-32bit: ignore
 binutils: ignore
 
-# it's using update-alternatives
 # XXX: usrmerge
 bash:
   /bin/{sh,bash}
@@ -187,6 +186,7 @@ sysuser-shadow:
 tar:
 terminfo-base:
 usbutils:
+vim-small:
 vlan:
 wget:
 ?wicked:
@@ -197,10 +197,6 @@ xz:
 
 <release_theme>-release: nodeps
 
-vim-small:
-  /
-  # avoid update-alternatives
-  e cd usr/bin ; if [ -f vim-small ] ; then ln -snf vim-small vim ; ln -snf vim-small vi ;fi
 
 # we have full samba in rescue-server
 if filelist ne 'rescue-server'

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -41,22 +41,6 @@ TEMPLATE binutils:
   r /usr/bin/ld
   s ld.bfd /usr/bin/ld
 
-TEMPLATE ruby.*-rubygem-suse-connect:
-  /
-  # avoid update-alternatives
-  e cd usr/bin ; ln -snf SUSEConnect* SUSEConnect
-
-TEMPLATE ruby.*-rubygem-nokogiri:
-  /
-  # avoid update-alternatives
-  e cd usr/bin ; find . -type l -name nokogiri\* -exec rm -f \{\} \; ; ln -snf nokogiri.ruby*-* nokogiri
-
-# fix the symlinks for the Ruby debugger if it is present
-TEMPLATE ruby.*-rubygem-byebug:
-  /
-  # avoid update-alternatives, remove the dangling symlinks and create a new one
-  e cd usr/bin ; find . -type l | grep byebug | xargs rm -rf ; ln -snf byebug.ruby* byebug
-
 # ruby maintainers can't really make up their minds on how to name their packages...
 TEMPLATE ruby.*-rubygem-yard: ignore
   # just a template that does nothing
@@ -212,9 +196,6 @@ python3-setuptools: ignore
 add_all skelcd-fallbackrepo-.*:
 
 python3-websockify:
-  /
-  # avoid update-alternatives
-  e cd usr/bin ; if [ -f websockify-3.* ] ; then ln -snf websockify-3.* websockify ; fi
 
 # normally python3-websockify would require python3-numpy but the
 # dependency is actually optional in the code - so avoid it to
@@ -222,9 +203,6 @@ python3-websockify:
 python3-numpy: ignore
 
 vim-small:
-  /
-  # avoid update-alternatives
-  e cd usr/bin ; if [ -f vim-small ] ; then ln -snf vim-small vim ; ln -snf vim-small vi ;fi
 
 <release_theme>-release: nodeps
 
@@ -246,7 +224,6 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
-# it's using update-alternatives
 # XXX: usrmerge
 bash:
   /bin/{sh,bash}
@@ -316,8 +293,6 @@ yast2:
 
 ruby:
   /
-  # avoid update-alternatives
-  r /etc/alternatives
   r /usr/bin/rake*
   r /usr/bin/{y2,}racc*
   r /usr/bin/rdoc*
@@ -465,10 +440,6 @@ endif
 
 if arch ne 's390' && arch ne 's390x'
   xorg-x11-server:
-    /
-    # avoid update-alternatives
-    e [ -f usr/<lib>/xorg/modules/extensions/xorg/xorg-libglx.so ] && ln -snf xorg/xorg-libglx.so usr/<lib>/xorg/modules/extensions/libglx.so ; true
-
   xrandr:
   ?xf86-input-evdev:
   ?xf86-input-libinput:
@@ -487,6 +458,7 @@ if arch ne 's390' && arch ne 's390x'
 
 endif
 
+iptables:
 mkfontscale:
 ?mkfontdir:
 setxkbmap:
@@ -561,7 +533,6 @@ libgbm*:
 
 icewm-lite:
   /usr/bin/icewm-lite
-  s /usr/bin/icewm-lite /usr/bin/icewm
 
 # don't include fonts - it prefers /usr/share/fonts/misc anyway
 fbiterm:
@@ -619,11 +590,6 @@ multipath-tools:
 graphviz-gnome: nodeps
   /usr/lib*/graphviz/libgvplugin_pango.so.*
 
-iptables:
-  /
-  # avoid update-alternatives
-  e cd usr/sbin ; if [ -f iptables-legacy ] ; then for i in iptables{,-restore,-save} ; do ln -snf iptables-legacy $i ; done ; fi
-  e cd usr/sbin ; if [ -f ip6tables-legacy ] ; then for i in ip6tables{,-restore,-save} ; do ln -snf ip6tables-legacy $i ; done ; fi
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -124,12 +124,10 @@ krb5:
   /usr/lib*/libgssapi_krb5.so.*
   /usr/lib*/libk5crypto.so.*
 
-# it's using update-alternatives
 # XXX: usrmerge
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
-  s bash usr/bin/sh
 
 dbus-1: prein
   /


### PR DESCRIPTION
## Problem

Some packages use `update-alternative` but the `update-alternative` package is not included to save space und running postinstall scripts is not possible in all cases anyway.

## Solution

Parse the postinstall scripts for `update-alternative` calls and create the expected symlinks.

The parser is rather simplistic and works only for reasonably formatted shell scripts. But for now at least it handles all cases well.