### PR TITLE
remove bind-libs BuildRequires

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -317,7 +317,6 @@ BuildRequires:  audit-libs
 BuildRequires:  bc
 BuildRequires:  bcache-tools
 BuildRequires:  bcm43xx-firmware
-BuildRequires:  bind-libs
 BuildRequires:  bind-utils
 BuildRequires:  blueprint-cursor-theme
 BuildRequires:  btrfsprogs


### PR DESCRIPTION
## Task

`bind-libs` is obsolete and not used at all. Remove dependency.