### PR TITLE
adjust NVME config initialisation (bsc#1183230)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -56,7 +56,7 @@ fi
 
 # create NVMe config files
 if [ -x /usr/sbin/nvme ] ; then
-  /usr/sbin/nvme gen-hostnqn > /etc/nvme/hostnqn
+  { /usr/sbin/nvme-gen-hostnqn || /usr/sbin/nvme gen-hostnqn ; } > /etc/nvme/hostnqn
   cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
 fi
 

--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -54,7 +54,10 @@ fi
 
 # keep some initrd config files for rescue system
 cd /mounts/initrd
-for i in etc/modprobe.d/blacklist.conf etc/modprobe.d/noload.conf etc/resolv.conf etc/sysconfig/network/* root/.ssh ; do
+for i in \
+  etc/modprobe.d/blacklist.conf etc/modprobe.d/noload.conf etc/resolv.conf \
+  etc/sysconfig/network/* root/.ssh etc/nvme \
+  ; do
   [ -f "$i" ] && cp -f "$i" "/$i"
   [ -d "$i" ] && cp -fr --parents "$i" /
 done
@@ -79,12 +82,6 @@ fi
 for i in $(cat /mounts/initrd/.base_modules) ; do
   modprobe -q -d /mounts/initrd $i
 done
-
-# create NVMe config files
-mount -t proc proc /proc
-nvme gen-hostnqn > /etc/nvme/hostnqn
-cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
-umount /proc
 
 if [ "$startshell" = 1 ] ; then
   mount -t proc proc /proc


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/473 to SLE15-SP3.

## Original Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1183230
- https://trello.com/c/fvglnkEV

`/etc/nvme/hostnqn` does not contain system UUID.

## Solution

Adjust config generation according to updated information from

- https://bugzilla.suse.com/show_bug.cgi?id=1183230#c11
- https://bugzilla.suse.com/show_bug.cgi?id=1183230#c22