### PR TITLE
build with kernel-default-extra on Leap (bsc#1184413, bsc#1183140)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -43,6 +43,7 @@ ExclusiveArch:  do_not_build
 %define with_reiserfs_kmp 0
 %define with_ssl_hmac 1
 %define with_exfat 0
+%define with_kernel_extra 0
 %bcond_without sbl
 %bcond_without vnc
 %bcond_with xen
@@ -64,6 +65,7 @@ ExclusiveArch:  do_not_build
 %if 0%{?is_opensuse}
 %define theme openSUSE
 %if 0%{?sle_version}
+%define with_kernel_extra 1
 # define the_version %(echo %sle_version | sed -Ee 's/^([0-9][0-9])(0|([0-9]))([0-9]).*/\\1.\\3\\4/')
 %define the_version \\$releasever
 %if "%{the_version}" == ""
@@ -385,6 +387,9 @@ BuildRequires:  jfsutils
 BuildRequires:  joe
 BuildRequires:  kbd
 BuildRequires:  kernel-default
+%if %with_kernel_extra
+BuildRequires:  kernel-default-extra
+%endif
 BuildRequires:  kernel-firmware
 BuildRequires:  kexec-tools
 BuildRequires:  khmeros-fonts


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184413
- https://bugzilla.suse.com/show_bug.cgi?id=1183140

Leap 15.3 uses the kernel config from sle15-sp3. That puts some unsupported but common modules into kernel-default-extra, which is not used to build the installation system.

Change spec file to include  kernel-default-extra when building for Leap.