### PR TITLE
enable multipathd in rescue system (bsc#1184686)

### DIFF
--- a/data/rescue/etc/multipath.conf
+++ b/data/rescue/etc/multipath.conf
@@ -1,0 +1,3 @@
+defaults {
+  find_multipaths smart
+}

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -435,6 +435,10 @@ e echo console >>etc/securetty
 # enable sysrq
 e perl -pi -e '\''s/^(ENABLE_SYSRQ=).*/$1"yes"/'\'' etc/sysconfig/sysctl
 
+# setup multipath config
+x etc/multipath.conf /etc
+E systemctl enable multipathd
+
 e ldconfig -r .
 
 # now run SuSEconfig


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/481 to SLE15-SP3.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184686
- https://bugzilla.suse.com/show_bug.cgi?id=1175560

The rescue system does not have multipath enabled by default. Which causes problems when there is a LVM or RAID setup on top of that.

## Solution

Enable multipath, but with `find_multipaths smart` - which checks for multipath'ed devices and leaves 'normal' devices alone.