### PR TITLE
build with kernel-default-optional on Leap (bsc#1184413)

### DIFF
--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -464,6 +464,7 @@ sub ReadRPM
 
     UnpackRPM RealRPM("$rpm->{name}-base"), $tdir;
     UnpackRPM RealRPM("$rpm->{name}-extra"), $tdir;
+    UnpackRPM RealRPM("$rpm->{name}-optional"), $tdir;
 
     my $kmp;
     for (split(',', $ConfigData{kmp_list})) {

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -389,6 +389,7 @@ BuildRequires:  kbd
 BuildRequires:  kernel-default
 %if %with_kernel_extra
 BuildRequires:  kernel-default-extra
+BuildRequires:  kernel-default-optional
 %endif
 BuildRequires:  kernel-firmware
 BuildRequires:  kexec-tools


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/485 to master branch.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184413

Leap 15.3 uses the kernel config from sle15-sp3. Modules neither in kernel-default nor kernel-default-extra are in kernel-default-optional.

Change spec file to include also kernel-default-optional when building for Leap.