### PR TITLE
allow loading of unsupported modules (bsc#1184413, bsc#1183140)

### DIFF
--- a/data/initrd/etc/99-unsupported-modules.conf
+++ b/data/initrd/etc/99-unsupported-modules.conf
@@ -1,0 +1,1 @@
+allow_unsupported_modules 1

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -694,6 +694,11 @@ endif
 r /etc/mtab
 s /proc/self/mounts /etc/mtab
 
+# override allow_unsupported_modules to allow loading all modules
+# this is needed in case kernel-default-{extra,optional} were used
+# see bsc#1184413, bsc#1183140
+x etc/99-unsupported-modules.conf /etc/modprobe.d
+
 # our own rules file which loads only pnp subsystem mods
 x etc/80-drivers.rules /usr/lib/udev/80-drivers.rules.no_modprobe
 

--- a/data/initrd/scripts/prepare_rescue
+++ b/data/initrd/scripts/prepare_rescue
@@ -55,7 +55,7 @@ fi
 # keep some initrd config files for rescue system
 cd /mounts/initrd
 for i in \
-  etc/modprobe.d/blacklist.conf etc/modprobe.d/noload.conf etc/resolv.conf \
+  etc/modprobe.d/{blacklist,noload,99-unsupported-modules}.conf etc/resolv.conf \
   etc/sysconfig/network/* root/.ssh etc/nvme \
   ; do
   [ -f "$i" ] && cp -f "$i" "/$i"


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/489 to master branch.

## Original problem

With https://github.com/openSUSE/installation-images/pull/480 and https://github.com/openSUSE/installation-images/pull/491 kernel-default-extra and kernel-default-optional are used to build the installation system on Leap 15.3.

But modprobe will refuse to load these extra modules unless the `allow_unsupported_modules` config option is set.