### PR TITLE
add udev rules for NVMf autoconnect in the installation system (bsc#1184908)

### DIFF
--- a/data/initrd/etc/90-nvmf-discovery.rules
+++ b/data/initrd/etc/90-nvmf-discovery.rules
@@ -1,0 +1,3 @@
+ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
+      ENV{NVMEFC_HOST_TRADDR}=="*", ENV{NVMEFC_TRADDR}=="*", \
+      RUN+="/bin/sh -c 'echo --transport=fc --host-traddr=$env{NVMEFC_HOST_TRADDR} --traddr=$env{NVMEFC_TRADDR} >> /etc/nvme/discovery.conf'"

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -704,6 +704,9 @@ x etc/99-unsupported-modules.conf /etc/modprobe.d
 # our own rules file which loads only pnp subsystem mods
 x etc/80-drivers.rules /usr/lib/udev/80-drivers.rules.no_modprobe
 
+# udev rules for NVMf autoconnect in the installation system (bsc#1184908)
+x etc/90-nvmf-discovery.rules /usr/lib/udev/rules.d
+
 # don't let udev lock the DVD tray
 R s/--lock-media/--unlock-media/g usr/lib/udev/rules.d/60-cdrom_id.rules
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1184908

The default udev rules for NVMf autoconnect relies on systemd, which is not available during installation.

Add custom udev rules (provided in https://bugzilla.suse.com/show_bug.cgi?id=1184908#c19).