### PR TITLE
add USB Type-C modules (bsc#1184867)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -399,6 +399,7 @@ kernel/drivers/usb/serial/.*
 kernel/drivers/usb/storage/.*
 kernel/drivers/usb/dwc2/.*
 kernel/drivers/usb/dwc3/.*
+kernel/drivers/usb/typec/tcpm/.*
 
 
 [FireWire]

--- a/etc/module.config
+++ b/etc/module.config
@@ -399,7 +399,7 @@ kernel/drivers/usb/serial/.*
 kernel/drivers/usb/storage/.*
 kernel/drivers/usb/dwc2/.*
 kernel/drivers/usb/dwc3/.*
-kernel/drivers/usb/typec/tcpm/.*
+kernel/drivers/usb/typec/.*
 
 
 [FireWire]

--- a/etc/module.list
+++ b/etc/module.list
@@ -251,7 +251,7 @@ kernel/drivers/pci/controller/
 kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
 kernel/drivers/watchdog/
-
+kernel/drivers/usb/typec/tcpm/
 
 kernel/drivers/dma/bcm2835-dma.ko
 kernel/drivers/dma/tegra20-apb-dma.ko

--- a/etc/module.list
+++ b/etc/module.list
@@ -251,7 +251,7 @@ kernel/drivers/pci/controller/
 kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
 kernel/drivers/watchdog/
-kernel/drivers/usb/typec/tcpm/
+kernel/drivers/usb/typec/
 
 kernel/drivers/dma/bcm2835-dma.ko
 kernel/drivers/dma/tegra20-apb-dma.ko


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1185010

Add USB Type-C modules (all of `kernel/drivers/usb/typec/*.ko.xz`).

This extends https://github.com/openSUSE/installation-images/pull/484 which included only those in the `tcpm` subdir.

## Related

- https://github.com/openSUSE/installation-images/pull/484
- https://bugzilla.suse.com/show_bug.cgi?id=1184867