### PR TITLE
fix NVMf autoconnect udev rule (bsc#1184908)

### DIFF
--- a/data/initrd/etc/90-nvmf-discovery.rules
+++ b/data/initrd/etc/90-nvmf-discovery.rules
@@ -1,3 +1,3 @@
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
       ENV{NVMEFC_HOST_TRADDR}=="*", ENV{NVMEFC_TRADDR}=="*", \
-      RUN+="/bin/sh -c 'echo --transport=fc --host-traddr=$env{NVMEFC_HOST_TRADDR} --traddr=$env{NVMEFC_TRADDR} >> /etc/nvme/discovery.conf'"
+      RUN+="/usr/sbin/nvme connect-all --transport=fc --host-traddr=$env{NVMEFC_HOST_TRADDR} --traddr=$env{NVMEFC_TRADDR}"


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/499 to master branch.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1184908

The udev rule provide in https://github.com/openSUSE/installation-images/pull/497 did not work as expected.

Use the [modified version](https://bugzilla.suse.com/show_bug.cgi?id=1184908#c37).