### PR TITLE
trigger automatic nvme discovery (bsc#1184908)

### DIFF
--- a/data/initrd/etc/90-nvmf-discovery.rules
+++ b/data/initrd/etc/90-nvmf-discovery.rules
@@ -1,3 +1,6 @@
+ACTION=="add", SUBSYSTEM=="fc", DEVPATH=="/devices/virtual/fc/fc_udev_device", \
+      RUN+="/bin/sh -c 'echo add > /sys/class/fc/fc_udev_device/nvme_discovery'"
+
 ACTION=="change", SUBSYSTEM=="fc", ENV{FC_EVENT}=="nvmediscovery", \
       ENV{NVMEFC_HOST_TRADDR}=="*", ENV{NVMEFC_TRADDR}=="*", \
       RUN+="/usr/sbin/nvme connect-all --transport=fc --host-traddr=$env{NVMEFC_HOST_TRADDR} --traddr=$env{NVMEFC_TRADDR}"


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184908

FC NVME devices are not added automatically.