### PR TITLE
extend 'exists' operator to test for a specfic type

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -79,7 +79,8 @@ variables don't have a starting `'$'` and are implicitly environment
 variables. The only exceptions to this are `abuild` and `arch`.
 
 Also, you can use `exists(PACKAGE)` to test for a specific package or
-`exists(PACKAGE, FILE)` to test for a file in a package.
+`exists(PACKAGE, FILE)` to test for a file in a package or
+`exists(PACKAGE, FILE, TYPE)` to test for a file of a specific type.
 
 Note that the test for `FILE` is made in the unpacked rpm stored in the
 internal cache. So unless it's an absolute path you can walk out of the root
@@ -105,6 +106,11 @@ endif
 
 # only if package foo has a file /usr/bin/bar
 if exists(foo, usr/bin/bar)
+# ...
+endif
+
+# only if package foo has a link /usr/bin/bar
+if exists(foo, usr/bin/bar, l)
 # ...
 endif
 

--- a/lib/AddFiles.pm
+++ b/lib/AddFiles.pm
@@ -942,13 +942,16 @@ sub find_missing_packs
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Check if an rpm contains a file.
 #
-# rpm_has_file(rpm, file)
+# rpm_has_file(rpm, file, type)
 #
 # If file is missing, verifies only existence of rpm.
+# If type is specified, types must match.
+#
+# type is perl's -X operator (without the '-').
 #
 sub rpm_has_file
 {
-  my ($rpm, $file) = @_;
+  my ($rpm, $file, $type) = @_;
 
   return 0 if !RealRPM $rpm;
 
@@ -958,7 +961,9 @@ sub rpm_has_file
 
   return 0 if !$rpm_dir;
 
-  return -e "$rpm_dir/rpm/$file";
+  $type = 'e' if !$type;
+
+  return eval "-$type \"$rpm_dir/rpm/$file\"";
 }
 
 
@@ -982,8 +987,7 @@ sub fixup_re
     substr($re, length($2), length($3)) = $val;
   }
 
-  $re =~ s/\bexists\(([^),]+),\s*([^)]*)\)/rpm_has_file($1, $2) ? 1 : 0/eg;
-  $re =~ s/\bexists\(([^)]*)\)/rpm_has_file($1) ? 1 : 0/eg;
+  $re =~ s/\bexists\(([^),]+)(?:,\s*([^),]*))?(?:,\s*([^),]*))?\)/rpm_has_file($1, $2, $3) ? 1 : 0/eg;
 
   return $re;
 }


### PR DESCRIPTION
## Task

Add 3rd TYPE argument to `exists` function: that is, allow `exists(PACKAGE, FILE, TYPE)`, like:

```
if exists(filesystem, /lib, l)
...
endif
```