### PR TITLE
make usrmerge case depend on /lib link in filesystem package

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -3,8 +3,8 @@ d dev etc mnt proc tmp var usr/{bin,sbin,lib}
 if exists(filesystem, usr/lib64)
 d usr/lib64
 endif
-# filesystem requires compat-usrmerge-tools in usrmerged case, so trigger on that.
-if exists(compat-usrmerge-tools)
+# filesystem has /lib link in usrmerged case
+if exists(filesystem, /lib, l)
 s usr/bin /bin
 s usr/sbin /sbin
 s usr/lib /lib

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -4,8 +4,8 @@ d mnt proc sys tmp mounts root download scripts usr/{bin,sbin,lib}
 if exists(filesystem, usr/lib64)
 d usr/lib64
 endif
-# filesystem requires compat-usrmerge-tools in usrmerged case, so trigger on that.
-if exists(compat-usrmerge-tools)
+# filesystem has /lib link in usrmerged case
+if exists(filesystem, /lib, l)
 s usr/bin /bin
 s usr/sbin /sbin
 s usr/lib /lib

--- a/data/initrd/modules.file_list
+++ b/data/initrd/modules.file_list
@@ -4,8 +4,8 @@ s lib/modules/<kernel_ver>/initrd modules
 
 <kernel_rpm>:
 
-  # temporary
-  if exists(compat-usrmerge-tools)
+  # temporary: usrmerge
+  if exists(filesystem, /lib, l)
     L usr/lib/firmware fw
   else
     L lib/firmware fw
@@ -61,8 +61,8 @@ L boot/System.map* System.map
 e /sbin/depmod -a -b . -F System.map <kernel_ver>
 r System.map
 
-# copy needed firmware files
-if exists(compat-usrmerge-tools)
+# usrmerge: copy needed firmware files
+if exists(filesystem, /lib, l)
   d usr/lib/firmware
 else
   d lib/firmware

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -5,8 +5,8 @@ d dev etc home mnt proc sys tmp root usr/{bin,sbin,lib}
 if exists(filesystem, usr/lib64)
 d usr/lib64
 endif
-# filesystem requires compat-usrmerge-tools in usrmerged case, so trigger on that.
-if exists(compat-usrmerge-tools)
+# filesystem has /lib link in usrmerged case
+if exists(filesystem, /lib, l)
 s usr/bin /bin
 s usr/sbin /sbin
 s usr/lib /lib

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -4,8 +4,8 @@ d /usr/{bin,lib,libexec,sbin,share}
 if exists(filesystem, usr/lib64)
 d usr/lib64
 endif
-# filesystem requires compat-usrmerge-tools in usrmerged case, so trigger on that.
-if exists(compat-usrmerge-tools)
+# filesystem has /lib link in usrmerged case
+if exists(filesystem, /lib, l)
 s usr/bin /bin
 s usr/sbin /sbin
 s usr/lib /lib

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -5,8 +5,8 @@ d dev etc home mnt proc sys tmp root usr/{bin,sbin,lib}
 if exists(filesystem, usr/lib64)
 d usr/lib64
 endif
-# filesystem requires compat-usrmerge-tools in usrmerged case, so trigger on that.
-if exists(compat-usrmerge-tools)
+# filesystem has /lib link in usrmerged case
+if exists(filesystem, /lib, l)
 s usr/bin /bin
 s usr/sbin /sbin
 s usr/lib /lib


### PR DESCRIPTION
## Task

If `filesystem` package contains a `/lib` link, assume the /usr merge has happened.