### PR TITLE
no more libstoragemgmt-netapp-plugin

### DIFF
--- a/data/root/libstoragemgmt.file_list
+++ b/data/root/libstoragemgmt.file_list
@@ -2,7 +2,6 @@ TEMPLATE:
   /
 
 libstoragemgmt:
-libstoragemgmt-netapp-plugin:
 libstoragemgmt-smis-plugin:
 
 AUTODEPS:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -650,7 +650,6 @@ BuildRequires:  grub2-arm-efi
 BuildRequires:  grub2-riscv64-efi
 %endif
 # inst-sys module for libstoragemgmt
-BuildRequires:  libstoragemgmt-netapp-plugin
 BuildRequires:  libstoragemgmt-smis-plugin
 # our images are not reproducible and it's taking time
 #!BuildIgnore:  build-compare


### PR DESCRIPTION
## Task

`libstoragemgmt-netapp-plugin` is gone, remove it.

See https://build.opensuse.org/request/show/888376.