### PR TITLE
Use linuxrc option reboot_timeout to configure the timeout before reboot

### DIFF
--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -75,7 +75,7 @@ e echo "defaultrepo:	`default_repo`" >>linuxrc.config
 
 e echo "KexecReboot:    1" >>linuxrc.config
 
-e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct" >>linuxrc.config
+e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout" >>linuxrc.config
 
 if YAST_SELFUPDATE ne ""
   e echo "SelfUpdate:	<YAST_SELFUPDATE>" >>linuxrc.config


### PR DESCRIPTION
Backport linuxrc option reboot_timeout to 15 SP1

https://progress.opensuse.org/issues/89716

See https://github.com/yast/yast-installation/pull/950 && https://github.com/yast/yast-yast2/pull/1159