### PR TITLE
create NVMe config files before udevd is started (bsc#1184908)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -54,12 +54,6 @@ if [ -x /usr/sbin/wpa_supplicant ] ; then
   /usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -B -f /var/log/wpa_supplicant.log
 fi
 
-# create NVMe config files
-if [ -x /usr/sbin/nvme ] ; then
-  { /usr/sbin/nvme-gen-hostnqn || /usr/sbin/nvme gen-hostnqn ; } > /etc/nvme/hostnqn
-  cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
-fi
-
 if [ -x usr/sbin/wickedd ] ; then
   debug_opts="--debug mini --log-target stderr:time,pid,ident"
   if [ -n "$linuxrc_debug" ] ; then

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -26,6 +26,12 @@ if [ -n "$linuxrc_no_auto_assembly" ] ; then
   echo 'ENV{ANACONDA}="yes"' > /run/udev/rules.d/00-inhibit.rules
 fi
 
+# create NVMe config files before udevd is started (bsc#1184908)
+if [ ! -f /etc/nvme/hostnqn -a -x /usr/sbin/nvme ] ; then
+  { /usr/sbin/nvme-gen-hostnqn || /usr/sbin/nvme gen-hostnqn ; } > /etc/nvme/hostnqn
+  cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
+fi
+
 # start udevd
 echo -n "Starting udevd "
 if [ -n "$linuxrc_debug" ] ; then


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1184908#c78

The nvme config is created too late for fc nvme discovery to work correctly.

## Solution

Move the nvme config creation into the `udev_setup` script.