### PR TITLE
trigger automatic nvme discovery in udev start script (bsc#1184908)

### DIFF
--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -54,12 +54,6 @@ if [ -x /usr/sbin/wpa_supplicant ] ; then
   /usr/sbin/wpa_supplicant -c /etc/wpa_supplicant/wpa_supplicant.conf -u -B -f /var/log/wpa_supplicant.log
 fi
 
-# create NVMe config files
-if [ -x /usr/sbin/nvme ] ; then
-  { /usr/sbin/nvme-gen-hostnqn || /usr/sbin/nvme gen-hostnqn ; } > /etc/nvme/hostnqn
-  cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
-fi
-
 if [ -x usr/sbin/wickedd ] ; then
   debug_opts="--debug mini --log-target stderr:time,pid,ident"
   if [ -n "$linuxrc_debug" ] ; then

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -38,6 +38,9 @@ fi
 /usr/bin/udevadm trigger --type=subsystems --action=add
 /usr/bin/udevadm trigger --type=devices --action=add
 
+# add fc nvme devices (bsc#1184908)
+echo add > /sys/class/fc/fc_udev_device/nvme_discovery
+
 # 10 min - just long enough
 /usr/bin/udevadm settle --timeout=100
 

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -26,6 +26,12 @@ if [ -n "$linuxrc_no_auto_assembly" ] ; then
   echo 'ENV{ANACONDA}="yes"' > /run/udev/rules.d/00-inhibit.rules
 fi
 
+# create NVMe config files before udevd is started (bsc#1184908)
+if [ ! -f /etc/nvme/hostnqn -a -x /usr/sbin/nvme ] ; then
+  { /usr/sbin/nvme-gen-hostnqn || /usr/sbin/nvme gen-hostnqn ; } > /etc/nvme/hostnqn
+  cut -d : -f 3 /etc/nvme/hostnqn > /etc/nvme/hostid
+fi
+
 # start udevd
 echo -n "Starting udevd "
 if [ -n "$linuxrc_debug" ] ; then


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/507 and https://github.com/openSUSE/installation-images/pull/508 to `master` branch.

## Original problems

https://bugzilla.suse.com/show_bug.cgi?id=1184908#c78

- FC NVME devices are not added automatically.
- The nvme config is created too late for fc nvme discovery to work correctly.