### PR TITLE
openssh-server now uses /usr/etc for its config files (bsc#1185709)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -342,18 +342,13 @@ nfs-client:
 
 ?openssh-fips:
 
-if exists(openssh-server)
-  openssh:
-  openssh-server:
-else
-  openssh:
-endif
-    /
-    E prein
-    E postin
-    # enable root login bsc#1118114
-    R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
-
+openssh:
+openssh-server:
+  /
+  E prein
+  E postin
+  # enable root login bsc#1118114
+  e echo "PermitRootLogin yes" > etc/ssh/sshd_config.d/10_root_login.conf
 
 :
 

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -633,16 +633,13 @@ endif
 
 ?openssh-fips:
 
-if exists(openssh-server)
-  openssh:
-  openssh-server:
-else
-  openssh:
-endif
-    /
-    t /etc/sysconfig/ssh
-    # enable root login bsc#1118114
-    R s/^\s*#\s*(PermitRootLogin)\b.*/$1 yes/ /etc/ssh/sshd_config
+openssh:
+openssh-server:
+  /
+  E prein
+  E postin
+  # enable root login bsc#1118114
+  e echo "PermitRootLogin yes" > etc/ssh/sshd_config.d/10_root_login.conf
 
 fonts-config:
   /


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1185709

The latest `openssh-server` package moved its config files to `/usr/etc`. Adjust to work with old and new location.

## Solution

Avoid all the hassle and put a config blob into `/etc/ssh/sshd_config.d`. That works also for the 'old' `openssh-server` package.

## Bonus

Drop support for the ancient unsplit `openssh` package.