### PR TITLE
Add chipidea modules (bsc#1184867)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -400,6 +400,7 @@ kernel/drivers/usb/storage/.*
 kernel/drivers/usb/dwc2/.*
 kernel/drivers/usb/dwc3/.*
 kernel/drivers/usb/typec/.*
+kernel/drivers/usb/chipieda/.*
 
 
 [FireWire]

--- a/etc/module.list
+++ b/etc/module.list
@@ -252,6 +252,7 @@ kernel/drivers/mailbox/
 kernel/drivers/pinctrl/
 kernel/drivers/watchdog/
 kernel/drivers/usb/typec/
+kernel/drivers/usb/chipidea/
 
 kernel/drivers/dma/bcm2835-dma.ko
 kernel/drivers/dma/tegra20-apb-dma.ko


### PR DESCRIPTION
Add chipidea modules as requested at (https://bugzilla.suse.com/show_bug.cgi?id=1184867).

- https://trello.com/c/wbmTEB8b/2470-1-tw-1184867-nxp-imx8mm-missing-kernel-modules-in-initrd
