### PR TITLE
Keep /usr/lib/ld*so* also if lib64 exists

### DIFF
--- a/gefrickel
+++ b/gefrickel
@@ -78,6 +78,12 @@ done
 # need to keep the linker in usrmerge case
 if [ -n "$pfx" ]; then
   mv $lib_dir/ld-* b/$lib_dir || :
+  # If ^ moved from lib64, move from lib as well.
+  # aarch64 has lib64, but yet uses /lib/ld-linux-aarch64.so.1.
+  if [ -d ${pfx}lib64 ] && stat ${pfx}lib/ld-* >/dev/null 2>&1; then
+    mkdir -p b/${pfx}lib
+    mv ${pfx}lib/ld-* b/${pfx}lib || :
+  fi
 fi
 
 # empty usr/sbin is needed to avoid bsc#1169094 (cross-filesystem relative

--- a/gefrickel
+++ b/gefrickel
@@ -77,12 +77,12 @@ for i in $lib_dir/lib* $lib_dir/.lib* $lib_dir/lp64d; do
 done
 # need to keep the linker in usrmerge case
 if [ -n "$pfx" ]; then
-  mv $lib_dir/ld-* b/$lib_dir || :
+  mv $lib_dir/ld*so* b/$lib_dir || :
   # If ^ moved from lib64, move from lib as well.
   # aarch64 has lib64, but yet uses /lib/ld-linux-aarch64.so.1.
-  if [ -d ${pfx}lib64 ] && stat ${pfx}lib/ld-* >/dev/null 2>&1; then
+  if [ -d ${pfx}lib64 ] && stat ${pfx}lib/ld*so* >/dev/null 2>&1; then
     mkdir -p b/${pfx}lib
-    mv ${pfx}lib/ld-* b/${pfx}lib || :
+    mv ${pfx}lib/ld*so* b/${pfx}lib || :
   fi
 fi
 


### PR DESCRIPTION
While on x86_64, the runtime linker is /lib64/ld-linux-x86-64.so.2, it's still
in /lib/ on aarch64 (/lib/ld-linux-aarch64.so.1). Without this, the file is
missing and execution fails.

Verified to fix the aarch64 install initrd. Not tested anywhere else.

(CC @lnussel)