### PR TITLE
etc: update module.config to match 5.13

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -341,6 +341,7 @@ kernel/drivers/net/phy/.*
 kernel/drivers/net/team/.*
 kernel/drivers/net/tokenring/.*
 kernel/drivers/net/wireguard/.*
+kernel/drivers/net/wwan/.*
 kernel/net/9p/.*
 kernel/net/ieee802154/.*
 kernel/net/ipv4/.*


### PR DESCRIPTION
5.13 brought a new subsystem: `net/wwan`, add it to `[network]`