### PR TITLE
adobe-sourcesanspro-fonts have their font names changed (bsc#1188927)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -540,8 +540,15 @@ icewm-lite:
 fbiterm:
   /usr/bin/fbiterm
 
-?adobe-sourcesanspro-fonts:
-  /usr/share/fonts/truetype/SourceSansPro-{Regular,Light,Semibold}.otf
+if exists(adobe-sourcesanspro-fonts,/usr/share/fonts/truetype/SourceSansPro-Regular.otf)
+  adobe-sourcesanspro-fonts:
+    /usr/share/fonts/truetype/SourceSansPro-{Regular,Light,Semibold}.otf
+endif
+
+if exists(adobe-sourcesanspro-fonts,/usr/share/fonts/truetype/SourceSans3-Regular.otf)
+  adobe-sourcesanspro-fonts:
+    /usr/share/fonts/truetype/SourceSans3-{Regular,Light,Semibold}.otf
+endif
 
 dejavu-fonts:
   /usr/share/fonts/truetype/DejaVuSans*.ttf


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1188927

`adobe-sourcesanspro-fonts` changed font names from "Source Sans Pro" to "Source Sans 3". Also the filenames.

## Solution

Adjust to work with old and new package.

## Note

This also requires font name changes in

- [yast2-qt-branding-openSUSE:/usr/share/YaST2/theme/current/wizard/style.qss](https://github.com/openSUSE/branding/blob/tumbleweed/yast/style.qss)
- [yast2-qt-branding-openSUSE:/usr/share/YaST2/theme/current/wizard/installation.qss](https://github.com/openSUSE/branding/blob/tumbleweed/yast/installation.qss)