### PR TITLE
fix getting the kernel file name

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -14,7 +14,7 @@ repository = standard
 ; *** These are actually perl regexps! ***
 ;
 [KernelImage]
-default	= vmlinuz-
+default	= vmlinuz
 alpha	= vmlinuz
 ppc	= vmlinux
 ppc64	= vmlinux

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -566,7 +566,9 @@ sub KernelImg
     next unless s#.*/boot/##;
     next if /autoconf|config|shipped|version/;		# skip obvious garbage
     my ($f, $l) = split(/ /);
-    if($f =~ m#^$ConfigData{kernel_img}#) {
+    # Explicitly require the kernel file to have a version number attached
+    # with a '-', like NAME-VERSION-VARIANT.
+    if($f =~ m#^$ConfigData{kernel_img}\-#) {
       $l =~ s#.*/## if ($l);
       push @k_images, $l?$l:$f;
     }


### PR DESCRIPTION
## Task

The script needs to identify the actual kernel file in the kernel package. That's not obvious as there are different name variants on each architecture.

The base name is pre-configured in [etc/config](https://github.com/openSUSE/installation-images/blob/sw_108/etc/config#L11-L28). The full name should look something like `/boot/BASENAME-VERSION-VARIANT`.

The existing code assumed there might be name variants without `-VERSION` attached - but this is no longer the case. So simplify the code to avoid ambiguities.