### PR TITLE
ensure crypto-policies are added properly (bsc#1183082)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -41,7 +41,12 @@ e cp -a /dev/* dev
 #
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+# Some packages use LUA for their pre/post scripts; there's nothing else
+# than running rpm to install these - marked with the 'direct' tag.
+
 TEMPLATE system-user-root: direct
+
+TEMPLATE crypto-policies: direct
 
 TEMPLATE:
   /
@@ -549,7 +554,6 @@ openslp-server:
 # we just want the user & group entries
 chrony: nodeps
   E prein
-
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 #

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -33,7 +33,12 @@ TEMPLATE binutils:
   r /usr/bin/ld
   s ld.bfd /usr/bin/ld
 
+# Some packages use LUA for their pre/post scripts; there's nothing else
+# than running rpm to install these - marked with the 'direct' tag.
+
 TEMPLATE system-user-root: direct
+
+TEMPLATE crypto-policies: direct
 
 TEMPLATE system-user-.*|system-group-.*:
   /


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1183082

Crypto policies (symlinks in `/etc/crypto-policies/back-ends/`) are not setup properly preventing (in this case) gnutls from working.

## Solution

Ensure postinstall script of the `crypto-policies` package is run. It's written using rpm's LUA script language.