### PR TITLE
ensure /usr/share/pci.ids exists (bsc#1189767)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -48,6 +48,12 @@ TEMPLATE wicked|lvm2|syslog-service|util-linux|mdadm:
   /
   E postin
 
+# ensure /usr/share/pci.ids exists
+TEMPLATE hwdata:
+  /
+  e [ -e usr/share/pci.ids ] || ln -s pci.ids.d/pci.ids.dist usr/share/pci.ids
+  e [ -e usr/share/pci.ids ] || { echo "pci ids missing" ; false ; }
+
 TEMPLATE:
   /
 

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -75,6 +75,12 @@ TEMPLATE libiterm.*:
   /
   s ../s/screen usr/share/terminfo/i/iterm
 
+# ensure /usr/share/pci.ids exists
+TEMPLATE hwdata:
+  /
+  e [ -e usr/share/pci.ids ] || ln -s pci.ids.d/pci.ids.dist usr/share/pci.ids
+  e [ -e usr/share/pci.ids ] || { echo "pci ids missing" ; false ; }
+
 TEMPLATE:
   /
 


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/520 to SLE15-SP3.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1189767

`/usr/share/pci.ids` is missing. This causes lspci to display only numerical values.

## Solution

The file is created by a perl script during postinstall of newer versions of the `hwdata` package (basically copying a single file).

To avoid this, create a symlink manually if `pci.ids`  is missing.