### PR TITLE
Fix conditions for turning on/off zram (bcs#1187434)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -192,10 +192,10 @@ zram_swap_on() {
 }
 
 zram_swap_off() {
-  if [ -b $zram_swap_dev ] ; then
-    swapoff $zram_swap_dev
-    echo $zram_dev_index > /sys/class/zram-control/hot_remove
-  fi
+  [ -b "$zram_swap_dev" ] || return
+
+  swapoff $zram_swap_dev
+  echo $zram_dev_index > /sys/class/zram-control/hot_remove
 }
 
 create_zram_swap_disable_hook() {
@@ -211,7 +211,7 @@ create_zram_swap_disable_hook() {
 #! /bin/sh -x
 
 # at least 2 swap devices
-if [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
+if [ -b "$zram_swap_dev" ] && [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
   swapoff $zram_swap_dev
   echo $zram_dev_index > /sys/class/zram-control/hot_remove
 fi

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -181,7 +181,7 @@ zram_swap_on() {
     modprobe zram
     zram_dev_index=`cat /sys/class/zram-control/hot_add`
     zram_swap_dev=/dev/zram$zram_dev_index
-    if [ -b $zram_swap_dev ] ; then
+    if [ -b "$zram_swap_dev" ] ; then
       echo zstd > /sys/block/zram$zram_dev_index/comp_algorithm
       echo "$zram_swap" > /sys/block/zram$zram_dev_index/disksize
       mkswap $zram_swap_dev >/dev/null
@@ -192,10 +192,10 @@ zram_swap_on() {
 }
 
 zram_swap_off() {
-  [ -b "$zram_swap_dev" ] || return
-
-  swapoff $zram_swap_dev
-  echo $zram_dev_index > /sys/class/zram-control/hot_remove
+  if [ -b "$zram_swap_dev" ] ; then
+    swapoff $zram_swap_dev
+    echo $zram_dev_index > /sys/class/zram-control/hot_remove
+  fi
 }
 
 create_zram_swap_disable_hook() {
@@ -211,7 +211,7 @@ create_zram_swap_disable_hook() {
 #! /bin/sh -x
 
 # at least 2 swap devices
-if [ -b "$zram_swap_dev" ] && [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
+if [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
   swapoff $zram_swap_dev
   echo $zram_dev_index > /sys/class/zram-control/hot_remove
 fi


### PR DESCRIPTION
## Problem

`inst_setup` is trying to turn on/off zram even when zram feature is not enabled. Thus, a weird/useless error messages are shown when booting

> @swapoff: bad usage
> Try 'swapoff --help' for more information.
>  "cannot create /sys/class/zram-control/hot_remove: Directory nonexistent"

* https://trello.com/c/HKqMXVUK
* https://bugzilla.opensuse.org/show_bug.cgi?id=1187434

## Solution

Fix conditions while trying to turn zram on/off

---

<sub>NOTE: that error message comes from [dash](https://www.man7.org/linux/man-pages/man1/dash.1.html) shell.</sub>