### PR TITLE
increase minimal ext2 fs size to 128 kiB

### DIFF
--- a/lib/MakeExt2Image.pm
+++ b/lib/MakeExt2Image.pm
@@ -69,7 +69,7 @@ sub MakeExt2Image
 
   die "Error: you must be root to build images\n" if $>;
 
-  $blocks = 64 if $blocks < 64;
+  $blocks = 128 if $blocks < 128;
   $inodes = 64 if $inodes < 64;
 
   system "dd if=/dev/zero of=$file_name bs=1k count=$blocks 2>/dev/null" and return ( );


### PR DESCRIPTION
## Problem

Ext2 creation test case fails with latest `e2fsprogs`. The test image (64 kiB) is now considered too small to hold an ext2 fs.

## Solution

Increase minimal ext2 file system size to 128 kiB.

## Note

The test image size is calculated dynamically to fit the test data - which is rather small. So it invariably comes down to the minimal allowed size.