### PR TITLE
ensure perl-XML-Simple is available in installation system (bsc#1191498)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -184,6 +184,8 @@ parted:
 pciutils:
 perl-XML-Bare:
 perl-XML-NamespaceSupport:
+# ensure perl-XML-Simple stays in SLE15 (bsc#1191498)
+perl-XML-Simple:
 perl-gettext:
 polkit:
 procinfo:


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1191498
- https://trello.com/c/7LD0GSLc

perl-XML-Simple is used by some customers in their AutoYaST scripts. Ensure the package is available in the installation system even though the installer itself no longer needs it (since SLE15-SP3).