### PR TITLE
add kernel modules for USB PHYs (bsc#1184867)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -402,6 +402,7 @@ kernel/drivers/usb/dwc2/.*
 kernel/drivers/usb/dwc3/.*
 kernel/drivers/usb/typec/.*
 kernel/drivers/usb/chipidea/.*
+kernel/drivers/usb/phy/.*
 
 
 [FireWire]

--- a/etc/module.list
+++ b/etc/module.list
@@ -253,6 +253,7 @@ kernel/drivers/pinctrl/
 kernel/drivers/watchdog/
 kernel/drivers/usb/typec/
 kernel/drivers/usb/chipidea/
+kernel/drivers/usb/phy/
 
 kernel/drivers/dma/bcm2835-dma.ko
 kernel/drivers/dma/tegra20-apb-dma.ko


### PR DESCRIPTION
Module phy_generic is needed by i.MX8MM

- https://bugzilla.suse.com/show_bug.cgi?id=1184867