### PR TITLE
handle zstd compressed modules

### DIFF
--- a/bin/mlist2
+++ b/bin/mlist2
@@ -155,7 +155,7 @@ for (@cfg_file) {
     $l0 = $l[0];
     for $m1 (@fname_list) {
       $l[0] = $m1;
-      if($fname{$l[0]} =~ m#^$l0(?:\.xz)?$#) {
+      if($fname{$l[0]} =~ m#^$l0(?:\.xz|\.zst)?$#) {
         # print "$l0 - $fname{$l[0]} - $l[0]\n";
 
         $all{$l[0]} = 1;

--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -8,13 +8,13 @@ $fw_dir = shift;
 
 $err = 0;
 
-for $m (<$modules_dir/*.ko{,.xz}>) {
+for $m (<$modules_dir/*.ko{,.xz,.zst}>) {
   chomp $m;
 
   chomp(@l = `modinfo -F firmware $m`);
 
   $m =~ s#.*/##;
-  $m =~ s#\.ko(?:\.xz)?$##;
+  $m =~ s#\.ko(?:\.xz|\.zst)?$##;
 
   $fw{$m} = [ @l ] if @l;
 }

--- a/data/initrd/modules-config.file_list
+++ b/data/initrd/modules-config.file_list
@@ -10,6 +10,6 @@
   endif
   e /sbin/depmod -a -b . -F System.map <kernel_ver>
   e cp lib/modules/<kernel_ver>/modules.dep .
-  e find lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' | xargs modinfo >modules.info
+  e find lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.zst' | xargs modinfo >modules.info
   r System.map lib
 

--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -13,7 +13,7 @@ ln -snf /proc/self/fd/2 /dev/stderr
 
 # load some modules before udevd
 for i in edd scsi_dh_alua scsi_dh_emc scsi_dh_rdac ; do
-  [ -f /modules/$i.ko -o -f /modules/$i.ko.xz ] && modprobe $i
+  [ -f /modules/$i.ko -o -f /modules/$i.ko.xz -o -f /modules/$i.ko.zst ] && modprobe $i
 done
 
 # disable hotplug helper, udevd listens to netlink

--- a/gefrickel
+++ b/gefrickel
@@ -41,7 +41,7 @@ m_dir=`echo ${pfx}lib/modules/*/initrd`
 [ -d "$m_dir" ] || err "no kernel module dir"
 mkdir -p "b/$m_dir"
 for i in $base_modules ; do
-  for suffix in ko ko.xz; do
+  for suffix in ko ko.xz ko.zst; do
     [ -f $m_dir/$i.$suffix ] && mv $m_dir/$i.$suffix b/$m_dir
   done
 done

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -1256,7 +1256,7 @@ $ConfigData{fw_list} = $ConfigData{ini}{Firmware}{$arch} if $ConfigData{ini}{Fir
       die "Error: No kernel module found! (Looking for '*.ko*' in '$k_dir/rpm$ConfigData{kernel_module_dir}/*/kernel/')\n\n";
     }
     chomp $mod_type;
-    $mod_type =~ /\.(ko(?:\.xz)?)$/;
+    $mod_type =~ /\.(ko(?:\.xz|\.zst)?)$/;
     $ConfigData{module_type} = $1;
   }
 


### PR DESCRIPTION
Modules have `.ko.zst` suffix since kernel 5.15. Handle that in the scripts.