### PR TITLE
Merge pull request #521 from dgdavid/bsc-1187434

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -181,7 +181,7 @@ zram_swap_on() {
     modprobe zram
     zram_dev_index=`cat /sys/class/zram-control/hot_add`
     zram_swap_dev=/dev/zram$zram_dev_index
-    if [ -b $zram_swap_dev ] ; then
+    if [ -b "$zram_swap_dev" ] ; then
       echo zstd > /sys/block/zram$zram_dev_index/comp_algorithm
       echo "$zram_swap" > /sys/block/zram$zram_dev_index/disksize
       mkswap $zram_swap_dev >/dev/null
@@ -192,7 +192,7 @@ zram_swap_on() {
 }
 
 zram_swap_off() {
-  if [ -b $zram_swap_dev ] ; then
+  if [ -b "$zram_swap_dev" ] ; then
     swapoff $zram_swap_dev
     echo $zram_dev_index > /sys/class/zram-control/hot_remove
   fi


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/521 to SLE15-SP4.

## Original Task

`inst_setup` is trying to turn on/off zram even when zram feature is not enabled. Thus, a weird/useless error messages are shown when booting

> @swapoff: bad usage
> Try 'swapoff --help' for more information.
>  "cannot create /sys/class/zram-control/hot_remove: Directory nonexistent"

* https://trello.com/c/HKqMXVUK
* https://bugzilla.opensuse.org/show_bug.cgi?id=1187434

## Solution

Fix conditions while trying to turn zram on/off

---

<sub>NOTE: that error message comes from [dash](https://www.man7.org/linux/man-pages/man1/dash.1.html) shell.</sub>