### PR TITLE
enable Xorg on s390x (jsc#SLE-18632, jsc#SLE-22176)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -463,39 +463,34 @@ timezone:
   r /usr/share/zoneinfo/posix*
   r /usr/share/zoneinfo/right
 
-if !(arch eq 's390' || arch eq 's390x')
-  kbd:
-    /
-    m /usr/share/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
-endif
+kbd:
+  /
+  m /usr/share/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
 
 if roottrans
   include ../../tmp/base/yast2-trans.inc
 endif
 
-if arch ne 's390' && arch ne 's390x'
-  xorg-x11-server:
-    /
-    # avoid update-alternatives
-    e [ -f usr/<lib>/xorg/modules/extensions/xorg/xorg-libglx.so ] && ln -snf xorg/xorg-libglx.so usr/<lib>/xorg/modules/extensions/libglx.so ; true
+xorg-x11-server:
+  /
+  # avoid update-alternatives
+  e [ -f usr/<lib>/xorg/modules/extensions/xorg/xorg-libglx.so ] && ln -snf xorg/xorg-libglx.so usr/<lib>/xorg/modules/extensions/libglx.so ; true
 
-  xrandr:
-  ?xf86-input-evdev:
-  ?xf86-input-libinput:
-  xf86-input-wacom:
-  xf86-video-fbdev:
-  ?xf86-video-vesa:
-  ?xf86-video-qxl:
-  ?xf86-video-amdgpu:
+xrandr:
+?xf86-input-evdev:
+?xf86-input-libinput:
+?xf86-input-wacom:
+?xf86-video-fbdev:
+?xf86-video-vesa:
+?xf86-video-qxl:
+?xf86-video-amdgpu:
 
-  ?xf86-video-intel: nodeps
-    /usr/<lib>/xorg
+?xf86-video-intel: nodeps
+  /usr/<lib>/xorg
 
-  ?virtualbox-guest-x11: nodeps
-    /etc
-    /usr/<lib>/xorg/modules
-
-endif
+?virtualbox-guest-x11: nodeps
+  /etc
+  /usr/<lib>/xorg/modules
 
 mkfontscale:
 ?mkfontdir:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -296,9 +296,7 @@ ExcludeArch:    %ix86
 %if %with_reiserfs_kmp
 BuildRequires:  reiserfs-kmp-default
 %endif
-%ifnarch s390x
 BuildRequires:  xf86-input-libinput
-%endif
 BuildRequires:  google-roboto-fonts
 BuildRequires:  noto-sans-fonts
 %ifarch ia64 %ix86 x86_64


### PR DESCRIPTION
## Task

- https://trello.com/c/VowN3MsD
- https://jira.suse.com/browse/SLE-18632
- https://jira.suse.com/browse/SLE-22176
- https://bugzilla.suse.com/show_bug.cgi?id=1181700

Enable Qt GUI on s390x if a graphics driver (virtio-gpu) exists.

Since [sr#258210](https://build.suse.de/request/show/258210) an X11 server exists on s390x. This pr includes the related files also on s390x.