### PR TITLE
clean up Xorg config (bsc#1192678)

### DIFF
--- a/data/root/etc/xorg.conf.template
+++ b/data/root/etc/xorg.conf.template
@@ -1,46 +1,24 @@
 Section "Device"
-  Identifier "vboxvideo"
-  Driver  "vboxvideo"
-EndSection
-
-Section "Screen"
-  Identifier "vboxvideo"
-  Device "vboxvideo"
-EndSection
-
-
-Section "Device"
-  Identifier "vmware"
-  Driver  "vmware"
-EndSection
-
-Section "Screen"
-  Identifier "vmware"
-  Device "vmware"
-EndSection
-
-
-Section "Device"
   Identifier "modesetting"
   Driver  "modesetting"
   Option "PreferCloneMode" "true"
   Option "AccelMethod" "none"
 EndSection
+
 Section "Screen"
   Identifier "modesetting"
   Device "modesetting"
 EndSection
 
-
 Section "Device"
   Identifier "fbdev"
   Driver  "fbdev"
 EndSection
+
 Section "Screen"
   Identifier "fbdev"
   Device "fbdev"
 EndSection
-
 
 Section "Device"
   Identifier "vesa"
@@ -52,11 +30,8 @@ Section "Screen"
   Device "vesa"
 EndSection
 
-
 Section "ServerLayout"
   Identifier "Layout"
-  Screen  "vboxvideo"
-  Screen  "vmware"
   Screen  "modesetting"
   Screen  "fbdev"
   Screen  "vesa"

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -435,34 +435,27 @@ timezone:
   r /usr/share/zoneinfo/posix*
   r /usr/share/zoneinfo/right
 
-if !(arch eq 's390' || arch eq 's390x')
-  kbd:
-    /
-    m /usr/share/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
-endif
+kbd:
+  /
+  m /usr/share/fillup-templates/sysconfig.keyboard /etc/sysconfig/keyboard
 
 if roottrans
   include ../../tmp/base/yast2-trans.inc
 endif
 
-if arch ne 's390' && arch ne 's390x'
+# a 'real' X server might not always exist (on s390x, for example)
+if exists(xorg-x11-server,/usr/bin/Xorg)
   xorg-x11-server:
   xrandr:
   ?xf86-input-evdev:
   ?xf86-input-libinput:
-  xf86-input-wacom:
-  xf86-video-fbdev:
+  ?xf86-input-wacom:
+  ?xf86-video-fbdev:
   ?xf86-video-vesa:
-  ?xf86-video-qxl:
-  ?xf86-video-amdgpu:
-
-  ?xf86-video-intel: nodeps
-    /usr/<lib>/xorg
 
   ?virtualbox-guest-x11: nodeps
     /etc
     /usr/<lib>/xorg/modules
-
 endif
 
 iptables:


### PR DESCRIPTION
## Tasks

1. https://bugzilla.suse.com/show_bug.cgi?id=1192678
Xorg config was using obsolete drivers. Clean up config to essentially rely on kernel drm for video mode setup (with vesa fallback on x86).

2. enable Xorg on s390x (jsc#SLE-18632, jsc#SLE-22176)
This integrates https://github.com/openSUSE/installation-images/pull/536 - but makes it conditional on the existence of an Xorg server binary.

