### PR TITLE
xf86-input-libinput now exists on s390x

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -310,9 +310,7 @@ ExcludeArch:    %ix86
 %if %with_reiserfs_kmp
 BuildRequires:  reiserfs-kmp-default
 %endif
-%ifnarch s390x
 BuildRequires:  xf86-input-libinput
-%endif
 BuildRequires:  google-roboto-fonts
 BuildRequires:  noto-sans-fonts
 %ifarch ia64 %ix86 x86_64


### PR DESCRIPTION
## Task

This is a follow-up to https://github.com/openSUSE/installation-images/pull/543. `xf86-input-libinput` had been missing on s390x until now.