### PR TITLE
linuxrc handles LIBSTORAGE_* and YAST_* boot options (jsc#SLE-21308)

### DIFF
--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -70,7 +70,7 @@ e echo "defaultrepo:	`default_repo`" >>linuxrc.config
 
 e echo "KexecReboot:    1" >>linuxrc.config
 
-e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout" >>linuxrc.config
+e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout,LIBSTORAGE_*,YAST_*" >>linuxrc.config
 
 if YAST_SELFUPDATE ne ""
   e echo "SelfUpdate:	<YAST_SELFUPDATE>" >>linuxrc.config


### PR DESCRIPTION
## Task

- https://trello.com/c/RfFcN9P7
- https://jira.suse.com/browse/SLE-21308

YaST can be controlled via a number of different environment variables (boot options) during installation. They would show up in the bootloader configuration of the target system - which is usually not wanted.

## Solution

Add `LIBSTORAGE_*` and `YAST_*` to the `ptoptions` option.

The net effect is that these options do not end up in the target system's bootloader configuration.

## See also

- related linuxrc change: https://github.com/openSUSE/linuxrc/pull/278