### PR TITLE
always include bash -> sh link

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -70,6 +70,7 @@ AUTODEPS:
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
+  s bash usr/bin/sh
 
 binutils: ignore
 ca-certificates-mozilla:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -254,6 +254,7 @@ coreutils:
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
+  s bash usr/bin/sh
   s bash usr/bin/lsh
 
 ncurses-utils:

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -128,6 +128,7 @@ krb5:
 bash:
   /bin/{sh,bash}
   /usr/bin/bash
+  s bash usr/bin/sh
 
 dbus-1: prein
   /


### PR DESCRIPTION
## Task

The bash package does not include the symlink `bash -> sh` anymore. Instead, a new `bash-sh` package exists for that.

To avoid problems, always create this link explicitly. This was done in some places already - now do it in all places where the bash package is used.