### PR TITLE
don't add Y2* install boot options to target system (jsc#SLE-21308)

### DIFF
--- a/data/initrd/theme.file_list
+++ b/data/initrd/theme.file_list
@@ -70,7 +70,7 @@ e echo "defaultrepo:	`default_repo`" >>linuxrc.config
 
 e echo "KexecReboot:    1" >>linuxrc.config
 
-e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout,LIBSTORAGE_*,YAST_*" >>linuxrc.config
+e echo "PTOptions:	AutoUpgrade,productprofile,addon,XVideo,Screenmode,specialproduct,reboot_timeout,LIBSTORAGE_*,YAST_*,Y2*" >>linuxrc.config
 
 if YAST_SELFUPDATE ne ""
   e echo "SelfUpdate:	<YAST_SELFUPDATE>" >>linuxrc.config


### PR DESCRIPTION
## Task

- https://trello.com/c/RfFcN9P7

After discussion in review: add also `Y2*` variables to avoid them in target system's boot config.

## See also

- https://github.com/openSUSE/installation-images/pull/556