### PR TITLE
[package] Ignore missing-PT_GNU_STACK-section rpmlint warnings

### DIFF
--- a/obs/installation-images-rpmlintrc
+++ b/obs/installation-images-rpmlintrc
@@ -1,1 +1,2 @@
-addFilter("arch-independent-package-contains-binary-or-object ")
+addFilter("arch-independent-package-contains-binary-or-object ");
+addFilter("missing-PT_GNU_STACK-section ");


### PR DESCRIPTION
This error shows up on some grub modules on ppc64. As the warning
was non-critical on grub2 build itself, i-i should certainly not
care more for it
