### PR TITLE
[packaging] Do not require gdb on ppc ppc64 (big-endian archs)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -368,7 +368,9 @@ BuildRequires:  fbiterm
 BuildRequires:  finger
 BuildRequires:  fonts-config
 BuildRequires:  gamin-server
+%ifnarch ppc ppc64
 BuildRequires:  gdb
+%endif
 BuildRequires:  gettext-runtime-mini
 BuildRequires:  glibc-i18ndata
 BuildRequires:  gpart


### PR DESCRIPTION
gdb is not being built for those archs and is thus not available.
