### PR TITLE
Add s390x to architecture list for net_repos (boo#1193479)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -55,6 +55,9 @@ ExclusiveArch:  do_not_build
 %ifarch ppc64 ppc64le
 %define the_arch ppc
 %endif
+%ifarch s390x
+%define the_arch zsystems
+%endif
 %ifarch riscv64
 %define the_arch riscv
 %endif

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -74,7 +74,7 @@ ExclusiveArch:  do_not_build
 %define net_repo https://download.opensuse.org/distribution/leap/%{the_version}/repo/oss
 %else
 %define with_exfat 1
-%ifarch %arm aarch64 ppc64 ppc64le riscv64
+%ifarch %arm aarch64 ppc64 ppc64le riscv64 s390x
 %define net_repo https://download.opensuse.org/ports/%{the_arch}/tumbleweed/repo/oss/
 %else
 %define net_repo https://download.opensuse.org/tumbleweed/repo/oss


### PR DESCRIPTION
IBM has been testing our net installations for s390x.
The net iso image is pointing to x86 repos and not to our zsystems repos at the moment.
That is fixing the following bug:
https://bugzilla.opensuse.org/show_bug.cgi?id=1193479