### PR TITLE
do not reset standard file descriptors in inst_setup, linuxrc takes care (bsc#1193910, jsc#SLE-18632)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -42,10 +42,6 @@ fi
 # no old hotplug stuff
 echo  > /proc/sys/kernel/hotplug
 
-# FIXME fix udev to not delete valid device nodes
-# /proc/self/fd/N will fail
-exec < /dev/console > /dev/console 2>&1 3>&1
-
 yast="$1"
 shift
 echo "$yast" > /tmp/linuxrc_installer_name


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1193910
- https://jira.suse.com/browse/SLE-18632
- https://trello.com/c/LX0JUO1E

Forcing the descriptors to `/dev/console` interferes with linuxrc switching consoles. And it's not really needed anyway.

## See also

- https://github.com/openSUSE/linuxrc/pull/280