### PR TITLE
etc: update module.config to match 5.17

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -657,6 +657,7 @@ ifb
 ioc3
 ipwireless
 iscsi_trgt
+mctp-serial
 msdos
 netdevsim
 parport_ax88796


### PR DESCRIPTION
5.17 brought a new network module mctp-serial (MCTP serial transport).
Add it to the notuseful list as it is very specific module to be built
into installation images.