### PR TITLE
re-add mount.nfs (bsc#1195035)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -427,13 +427,11 @@ autoyast2-installation: nodeps
 lvm2: nodeps
   /etc
 
-# note: locale files are added in root image
-if exists(glibc-locale-base)
-  glibc-locale: ignore
-  glibc-locale-base:
-else
-  glibc-locale:
-endif
+# note: more locale files are added in root image
+glibc-locale: ignore
+glibc-locale-base:
+  /usr/lib/locale/en_US.utf8
+  s en_US.utf8 usr/lib/locale/C.utf8
   # charset encodings we might possibly need
   /usr/lib*/gconv/IBM1047.so
   /usr/lib*/gconv/ISO8859-1.so

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -165,15 +165,7 @@ terminfo:
 suse-module-tools:
   /etc/modprobe.d
 
-# XXX: usrmerge
 ?s390-tools:
-  /sbin/zfcp_*_configure
-  /sbin/zfcp_san_disc
-  /sbin/iucv_configure
-  /sbin/ctc_configure
-  /sbin/qeth_configure
-  /sbin/dasdinfo
-  /sbin/chzdev
   /usr/sbin/zfcp_*_configure
   /usr/sbin/zfcp_san_disc
   /usr/sbin/iucv_configure
@@ -194,9 +186,7 @@ kbd:
   /usr/share/kbd/consoletrans/trivial
   /usr/share/kbd/consolefonts/default8x16.psfu.gz
 
-# XXX: usrmerge
 cifs-utils:
-  /sbin/mount.cifs
   /usr/sbin/mount.cifs
 
 ?acpica:
@@ -204,11 +194,6 @@ cifs-utils:
 
 ?dmidecode:
   /usr/sbin/dmidecode
-
-# XXX: usrmerge
-?bootsplash:
-  /sbin/splash
-  /usr/sbin/splash
 
 if exists(wpa_supplicant)
   wpa_supplicant:
@@ -255,9 +240,7 @@ coreutils:
   # linuxrc needs it in /bin
   m /usr/bin/rm bin
 
-# XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
   s bash usr/bin/sh
   s bash usr/bin/lsh
@@ -266,10 +249,7 @@ ncurses-utils:
   /usr/bin/clear
   /usr/bin/tset
 
-# XXX: usrmerge
 iproute2:
-  /bin/ip
-  /sbin/ip
   /usr/bin/ip
   /usr/sbin/ip
 
@@ -277,7 +257,6 @@ open-iscsi:
   # must be writable
   /etc/iscsi
   c 644 0 0 /etc/iscsi/iscsid.conf
-
 
 util-linux:
   /usr/sbin/mkswap
@@ -288,14 +267,10 @@ util-linux:
   /usr/bin/setsid
   /usr/sbin/losetup
   /usr/sbin/blkid
+  /usr/sbin/nologin
 
-# XXX: usrmerge
 nfs-client:
-  /sbin/mount.nfs
-  /sbin/mount.nfs4
-  /sbin/umount.nfs
-  /sbin/umount.nfs4
-  /sbin/mount.nfs
+  /usr/sbin/mount.nfs
   /usr/sbin/mount.nfs4
   /usr/sbin/umount.nfs
   /usr/sbin/umount.nfs4
@@ -312,32 +287,18 @@ cryptsetup:
 ?libcryptsetup*-hmac:
 ?libgcrypt20-hmac:
 
-# XXX: usrmerge
 ntfs-3g:
   /
-  s mount.ntfs-3g /sbin/mount.ntfs
   s mount.ntfs-3g /usr/sbin/mount.ntfs
 
 ?kexec-tools: nodeps
   /usr/sbin/kexec
 
-# XXX: usrmerge
-if exists(blog)
-  blog:
-    /usr/lib*
-    /sbin/showconsole
-    /usr/sbin/showconsole
+blog:
+  /usr/sbin/showconsole
 
-  sysvinit-tools: nodeps
-    /sbin/startproc
-    /usr/sbin/startproc
-else
-  sysvinit-tools: nodeps
-    /sbin/showconsole
-    /sbin/startproc
-    /usr/sbin/showconsole
-    /usr/sbin/startproc
-endif
+sysvinit-tools: nodeps
+  /usr/sbin/startproc
 
 rpm:
   /usr/bin/rpm2cpio
@@ -394,30 +355,18 @@ shadow:
   /usr/sbin/useradd.local
   d /etc/skel
 
-# XXX: usrmerge
 pam:
-  /sbin
   /usr/sbin
   /etc
   /usr/etc
-  /lib*/libpam*.so.*
-  /lib*/security/pam_group.so
-  /lib*/security/pam_unix*.so
-  /lib*/security/pam_env.so
-  /lib*/security/pam_limits.so
-  /lib*/security/pam_umask.so
-  /lib*/security/pam_rootok.so
-  /lib*/security/pam_permit.so
-  /lib*/security/pam_deny.so
   /usr/lib*/libpam*.so.*
-  /usr/lib*/security/pam_group.so
-  /usr/lib*/security/pam_unix*.so
-  /usr/lib*/security/pam_env.so
-  /usr/lib*/security/pam_limits.so
-  /usr/lib*/security/pam_umask.so
-  /usr/lib*/security/pam_rootok.so
-  /usr/lib*/security/pam_permit.so
   /usr/lib*/security/pam_deny.so
+  /usr/lib*/security/pam_env.so
+  /usr/lib*/security/pam_group.so
+  /usr/lib*/security/pam_limits.so
+  /usr/lib*/security/pam_permit.so
+  /usr/lib*/security/pam_rootok.so
+  /usr/lib*/security/pam_umask.so
 
 if exists(plymouth)
   # Do not EVER consider another plymouth theme before ensuring it doesn't
@@ -443,7 +392,6 @@ if exists(plymouth)
 endif
 
 procps:
-  /bin/ps
   /usr/bin/ps
 
 # maybe we don't need everything...
@@ -555,6 +503,7 @@ rpcbind:
 
 # we just want the user & group entries
 openslp-server:
+  E groupadd -r daemon || true
   E prein
 
 # we just want the user & group entries
@@ -571,9 +520,7 @@ if with_gdb
   valgrind:
     /
 
-  # XXX: usrmerge
   kbd:
-    /bin/kbd_mode
     /usr/bin/kbd_mode
 
   strace:
@@ -585,17 +532,13 @@ if with_gdb
   libpython2_6-1_0:
     /usr/lib*
 
-  # XXX: usrmerge
   libexpat1:
-    /lib*/libexpat.so.*
     /usr/lib*/libexpat.so.*
 
   libprocps*:
     /
 
-  # XXX: usrmerge
   psmisc:
-    /bin/fuser
     /usr/bin/fuser
     /usr/bin/killall
     /usr/bin/pstree

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -49,7 +49,7 @@ TEMPLATE nfs-client|device-mapper|rpcbind|rsync|rsyslog|dmraid|multipath-tools:
   E prein
   E postin
 
-TEMPLATE wicked|lvm2|syslog-service|util-linux|mdadm:
+TEMPLATE wicked|lvm2|syslog-service|util-linux|mdadm|permissions-config:
   /
   E postin
 
@@ -74,6 +74,13 @@ filesystem:
 ?compat-usrmerge: ignore
 ?compat-usrmerge-tools: ignore
 
+glibc:
+bash:
+  /usr/bin/bash
+  s bash usr/bin/sh
+fillup:
+coreutils:
+
 AUTODEPS:
 
 dbus-1-x11: ignore
@@ -84,12 +91,6 @@ shared-mime-info: ignore
 update-alternatives: ignore
 device-mapper-32bit: ignore
 binutils: ignore
-
-# XXX: usrmerge
-bash:
-  /bin/{sh,bash}
-  /usr/bin/bash
-  s bash usr/bin/sh
 
 ?acpica:
 ?efibootmgr:
@@ -119,7 +120,6 @@ btrfsprogs:
 bzip2:
 checkmedia:
 cifs-utils:
-coreutils:
 cpio:
 cracklib-dict-full:
 cracklib:
@@ -135,10 +135,8 @@ e2fsprogs:
 ?exfatprogs:
 file-magic:
 file:
-fillup:
 findutils:
 finger:
-glibc:
 gpart:
 ?gptfdisk:
 grep:
@@ -198,6 +196,7 @@ sysuser-shadow:
 tar:
 terminfo-base:
 usbutils:
+util-linux:
 vim-small:
 vlan:
 wget:
@@ -348,7 +347,6 @@ rpcbind:
 rsync:
 syslog-service:
 rsyslog:
-util-linux:
 wicked:
 ?dmraid:
 mdadm:
@@ -439,9 +437,6 @@ e echo RC_LANG=\"en_US.UTF-8\" >>etc/sysconfig/language
 #endif
 
 e echo console >>etc/securetty
-
-# enable sysrq
-e perl -pi -e '\''s/^(ENABLE_SYSRQ=).*/$1"yes"/'\'' etc/sysconfig/sysctl
 
 # setup multipath config
 x etc/multipath.conf /etc

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -224,12 +224,8 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
-if exists(glibc-locale-base)
-  glibc-locale: ignore
-  glibc-locale-base:
-else
-  glibc-locale:
-endif
+glibc-locale: ignore
+glibc-locale-base:
   # charset encodings we might possibly need
   /usr/lib*/gconv/IBM1047.so
   /usr/lib*/gconv/ISO8859-1.so

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -404,12 +404,8 @@ gpg2:
 chrony:
 
 # note: gconv files are in initrd
-if exists(glibc-locale-base)
-  glibc-locale: ignore
-  glibc-locale-base:
-else
-  glibc-locale:
-endif
+glibc-locale: ignore
+glibc-locale-base:
   # built in base system
   d usr/lib
   e cp -a /tmp/locale usr/lib

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -65,6 +65,17 @@ TEMPLATE hwdata:
   e [ -e usr/share/pci.ids ] || ln -s pci.ids.d/pci.ids.dist usr/share/pci.ids
   e [ -e usr/share/pci.ids ] || { echo "pci ids missing" ; false ; }
 
+TEMPLATE ruby\d+\.\d+:
+  /
+  r /usr/bin/rake*
+  r /usr/bin/{y2,}racc*
+  r /usr/bin/rdoc*
+  r /usr/bin/ri*
+  r /usr/bin/bundle*
+  r /usr/bin/rbs*
+  r /usr/bin/typeprof*
+  r /usr/bin/rdbg*
+
 TEMPLATE:
   /
 
@@ -214,9 +225,7 @@ vim-small:
 # pull in yast2 installation related packages via package deps
 skelcd-control-<skelcd_ctrl_theme>:
 
-# XXX: usrmerge
 rpm:
-  /bin
   /etc
   /usr/bin
   /usr/lib*
@@ -229,22 +238,17 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
-# XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
   s bash usr/bin/sh
 
 # Note that this does not make it the default shell /bin/sh,
 # only scripts that explicitly want dash will use it,
 # so we are safe even if there are undetected bashisms in some scripts.
-# XXX: usrmerge
 dash:
-  /bin/dash
   /usr/bin/dash
 
 nfs-client:
-  /sbin/{u,}mount.nfs*
   /usr/sbin/{u,}mount.nfs*
   /usr/sbin/rpc.statd
   /usr/sbin/start-statd
@@ -270,7 +274,6 @@ diffutils:
   /usr/bin/{cmp,diff}
 
 less:
-  /etc/lesskey
   /usr/etc/lesskey
   /usr/bin/less
 
@@ -297,18 +300,6 @@ yast2:
   s /usr/sbin/yast2 /sbin/yast.ssh
 
 ruby:
-  /
-  r /usr/bin/rake*
-  r /usr/bin/{y2,}racc*
-  r /usr/bin/rdoc*
-  r /usr/bin/ri*
-  r /usr/bin/bundle*
-  r /usr/bin/rbs*
-  r /usr/bin/typeprof*
-  r /usr/bin/rdbg*
-  /usr/lib64/ruby/*/{racc,rdoc}
-  /usr/lib64/ruby/gems/*/gems/{minitest,racc,rake,rdoc,test-unit}-*
-  e cd usr/bin ; for i in erb gem irb ruby ; do [ -x $i ] || ln -snf ${i}.ruby2* $i ; done
 
 yast2-devtools:
   /usr/share/YaST2/data/devtools/bin/showy2log
@@ -326,9 +317,7 @@ yast2-installation:
 yast2-widget-demo:
 
 if arch eq 'ppc' || arch eq 'ppc64'
-  # XXX: usrmerge
   pdisk:
-    /sbin/pdisk
     /usr/sbin/pdisk
 
   hfsutils:
@@ -348,7 +337,6 @@ if arch eq 'ppc' || arch eq 'ppc64'
    s hattrib /usr/bin/hvol
 endif
 
-# XXX: usrmerge
 sysvinit-tools:
 
 krb5:
@@ -358,16 +346,9 @@ krb5:
   /usr/lib*/libgssapi_krb5.so.*
   /usr/lib*/libk5crypto.so.*
 
-# XXX: usrmerge
 pam:
   /usr/etc/pam.d
-  /etc/pam.d
   /etc
-  /lib*/security
-  /lib*/libpam.so.*
-  /lib*/libpam_misc.so.*
-  /lib*
-  /sbin
   /usr/lib*/security
   /usr/lib*/libpam.so.*
   /usr/lib*/libpam_misc.so.*
@@ -457,7 +438,7 @@ if exists(xorg-x11-server,/usr/bin/Xorg)
   ?xf86-video-vesa:
 
   ?virtualbox-guest-x11: nodeps
-    /etc
+    /usr/etc
     /usr/<lib>/xorg/modules
 endif
 
@@ -576,7 +557,7 @@ indic-fonts:
   /usr/share/fonts/truetype/TSCu_Paranar.ttf
 
 thai-fonts:
-  /usr/share/fonts/truetype/Loma*.ttf
+  /usr/share/fonts/opentype/thai/Loma*.otf
 
 khmeros-fonts:
   /usr/share/fonts/truetype/KhmerOS_sys.ttf
@@ -592,9 +573,7 @@ dmz-icon-theme-cursors:
     /usr/share/icons/DMZ
   endif
 
-# XXX: usrmerge
 multipath-tools:
-  /sbin
   /usr/sbin
 
 graphviz-gnome: nodeps
@@ -682,6 +661,9 @@ e mkfontdir usr/share/fonts/misc
 
 e mkfontscale usr/share/fonts/truetype
 e mkfontdir usr/share/fonts/truetype
+
+e mkfontscale usr/share/fonts/opentype
+e mkfontdir usr/share/fonts/opentype
 
 # remove /etc/os-release so it's not used accidentally
 r /etc/os-release

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -124,9 +124,7 @@ krb5:
   /usr/lib*/libgssapi_krb5.so.*
   /usr/lib*/libk5crypto.so.*
 
-# XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
   s bash usr/bin/sh
 
@@ -143,7 +141,6 @@ ncurses-utils:
   /usr/bin/tset
 
 less:
-  /etc/lesskey
   /usr/etc/lesskey
   /usr/bin/less
 
@@ -160,9 +157,7 @@ x /etc/ld.so.conf /etc
 # remove these:
 r root mnt tmp usr/libexec
 
-# XXX: usrmerge
 :
-  r /lib*/security/pam_userdb.so
   r /usr/lib*/security/pam_userdb.so
 
   x etc/inst_setup_ssh /sbin/
@@ -178,10 +173,8 @@ dmidecode:
 acpica:
   /usr/sbin/acpidump
 
-# XXX: usrmerge
 sysconfig:
-  /sbin
-  /usr/sbin
+  /
   # for modify_resolvconf
   d etc/sysconfig/network
   e echo MODIFY_RESOLV_CONF_DYNAMICALLY=\"yes\" >etc/sysconfig/network/config


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1195035

`mount.nfs` accidentally dropped from initrd as a result of a typo in the usrmerge changes.

## Solution

Add it back and fix a number of warnings and other bit-rot:

1. /usr/sbin/mount.nfs is back
2. remove references left to /bin and /sbin
3. add /usr/sbin/nologin to shut up warnings when adding system users
4. fix warnings about missing group entries
5. remove no longer existing stuff (like bootsplash)
6. fix ruby package handling
7. thai-fonts are in opentype format now
8. fix locale handling (include them in initrd)