### PR TITLE
use for build proper schema flavor (jsc#SLE-18820)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -546,7 +546,11 @@ BuildRequires:  xset
 BuildRequires:  xterm
 BuildRequires:  xz
 BuildRequires:  yast2-devtools
-BuildRequires:  yast2-schema
+%if "%flavor" == "SMO" || "%flavor" == "LeapMicro" || "%flavor" == "MicroOS"
+BuildRequires:  yast2-schema-micro
+%else
+BuildRequires:  yast2-schema-default
+%endif
 BuildRequires:  yast2-trans-allpacks
 BuildRequires:  yast2-widget-demo
 %if 0%{?with_storage_ng}


### PR DESCRIPTION
Feature: introduce product specific limited set of autoyast modules represented by limited yast2-schema.

Implementation: depending on flavor use proper schema package.

SP4 change https://github.com/openSUSE/installation-images/pull/570