### PR TITLE
include all of s390-tools in initrd (bsc#1195914)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -166,16 +166,6 @@ suse-module-tools:
   /etc/modprobe.d
 
 ?s390-tools:
-  /usr/sbin/zfcp_*_configure
-  /usr/sbin/zfcp_san_disc
-  /usr/sbin/iucv_configure
-  /usr/sbin/ctc_configure
-  /usr/sbin/qeth_configure
-  /usr/sbin/dasdinfo
-  /usr/sbin/chzdev
-  /usr/lib/udev
-  /etc/zkey
-  /boot
 
 kbd:
   /usr/bin/dumpkeys


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1195914

It's unclear when the s390-tools package will finally include the usrmerge changes.

## Solution

To avoid chosing the wrong path, do not hand-pick individual binaries but include the entire package.