### PR TITLE
always include bash -> sh links (jsc#SLE-18234)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -66,11 +66,12 @@ TEMPLATE:
 
 AUTODEPS:
 
-# it's using update-alternatives
+# update-alternatives & bash-sh split - give up and create expected symlinks manually
 # XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
+  s /usr/bin/bash bin/bash
+  s /usr/bin/sh bin/sh
   s bash usr/bin/sh
 
 binutils: ignore

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -255,11 +255,12 @@ coreutils:
   # linuxrc needs it in /bin
   m /usr/bin/rm bin
 
-# it's using update-alternatives
+# update-alternatives & bash-sh split - give up and create expected symlinks manually
 # XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
+  s /usr/bin/bash bin/bash
+  s /usr/bin/sh bin/sh
   s bash usr/bin/sh
   s bash usr/bin/lsh
 

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -85,11 +85,12 @@ update-alternatives: ignore
 device-mapper-32bit: ignore
 binutils: ignore
 
-# it's using update-alternatives
+# update-alternatives & bash-sh split - give up and create expected symlinks manually
 # XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
+  s /usr/bin/bash bin/bash
+  s /usr/bin/sh bin/sh
   s bash usr/bin/sh
 
 ?acpica:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -254,11 +254,12 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
-# it's using update-alternatives
+# update-alternatives & bash-sh split - give up and create expected symlinks manually
 # XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
+  s /usr/bin/bash bin/bash
+  s /usr/bin/sh bin/sh
   s bash usr/bin/sh
 
 # Note that this does not make it the default shell /bin/sh,

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -124,11 +124,12 @@ krb5:
   /usr/lib*/libgssapi_krb5.so.*
   /usr/lib*/libk5crypto.so.*
 
-# it's using update-alternatives
+# update-alternatives & bash-sh split - give up and create expected symlinks manually
 # XXX: usrmerge
 bash:
-  /bin/{sh,bash}
   /usr/bin/bash
+  s /usr/bin/bash bin/bash
+  s /usr/bin/sh bin/sh
   s bash usr/bin/sh
 
 dbus-1: prein


### PR DESCRIPTION
## Task

The `bash-sh`  split has reached SLE15-SP4.

This is similar to https://github.com/openSUSE/installation-images/pull/550 but additionally `bin` -> `usr/bin` links have also to be taken care of.