### PR TITLE
include all of s390-tools in initrd (bsc#1195914, bsc#1196923)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -165,25 +165,7 @@ terminfo:
 suse-module-tools:
   /etc/modprobe.d
 
-# XXX: usrmerge
 ?s390-tools:
-  /sbin/zfcp_*_configure
-  /sbin/zfcp_san_disc
-  /sbin/iucv_configure
-  /sbin/ctc_configure
-  /sbin/qeth_configure
-  /sbin/dasdinfo
-  /sbin/chzdev
-  /usr/sbin/zfcp_*_configure
-  /usr/sbin/zfcp_san_disc
-  /usr/sbin/iucv_configure
-  /usr/sbin/ctc_configure
-  /usr/sbin/qeth_configure
-  /usr/sbin/dasdinfo
-  /usr/sbin/chzdev
-  /usr/lib/udev
-  /etc/zkey
-  /boot
 
 kbd:
   /usr/bin/dumpkeys


### PR DESCRIPTION
This is a backport of #579 to the SLE-15-SP4 branch.

Done in the context of [bsc#1196923](https://bugzilla.suse.com/show_bug.cgi?id=1196923), which is caused because the initrd does not include a new tool that was added to `s390-tools` in that distribution.

So we decided it was simpler to just stop filtering the files from that package, since that filtering is causing more problems than it is solving. In fact, the size of initrd should not be a problem anymore; there used to be a 32MiB limit on certain s390 install methods, but we're way beyond that meanwhile.

So let's follow the same approach that seems to have worked for Tumbleweed.