### PR TITLE
add LeapMicro theme

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -92,6 +92,17 @@ grub2             = openSUSE
 plymouth          = openSUSE
 systemd           = openSUSE
 
+[Theme LeapMicro]
+image             = 350
+patch_zypp_config = 1
+release           = Leap-Micro
+skelcd            = SMO
+skelcd_ctrl       = SMO
+gfxboot           = openSUSE
+grub2             = openSUSE
+plymouth          = openSUSE
+systemd           = SMO
+
 [Theme SLES]
 image             = 600
 patch_zypp_config = 0


### PR DESCRIPTION
This is theme as we use it today in LeapMicro 5.2 (original suggestion by Ludwig). We might want to change that over the time but I'd really appreciate getting rid of the patch that we keep as of today.


https://build.opensuse.org/package/view_file/openSUSE:Leap:Micro:5.2/installation-images/leap-micro.diff?expand=1