### PR TITLE
Fix creation of openslp user (bsc#1196331, bsc#1197222)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -539,6 +539,8 @@ rpcbind:
 
 # we just want the user & group entries
 openslp-server:
+  # The script assumes the group daemon exists (bsc#1196331, bsc#1197222)
+  E groupadd -r daemon || true
   E prein
 
 # we just want the user & group entries


### PR DESCRIPTION
## Problem

When installing via VNC, the OpenSLP service fails to start making it impossible to find the system via SLP.

That happens because the user `openslp` used to boot the OpenSLP server does not exists in the inst-sys. We are quite sure that's the problem because if the boot process is interrupted using `STARTSHELL` and the user is then manually created with groupadd before proceeding, then OpenSLP runs.

The `openslp` user should be created in the inst-sys by the preinstallation script of the package `openslp-server` that contains the following command:

```
/usr/sbin/useradd -r -g daemon -d /var/lib/empty -s /sbin/nologin -c "openslp daemon" openslp 2>/dev/null || :
```

But that command cannot succeed if the group `daemon` is not there. That dependency, BTW, is declared in the spec file of the package:

```
PreReq:         /usr/sbin/useradd
Requires:       openslp
Requires(pre):  group(daemon)
```

## Solution

Ensure the group `daemon` is there when the prein script of `openslp-server` is executed.