### PR TITLE
add xrdb to inst-sys (bsc#1198294)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -109,7 +109,7 @@ sessreg: ignore
 shared-mime-info: ignore
 update-alternatives: ignore
 xinetd: ignore
-xrdb: ignore
+xrdb: nodeps
 icewm: ignore
 pkg-config: ignore
 syslog-service: ignore


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1198473
- https://trello.com/c/I3sou5vC

HiDPI handling still not working during installation.

## Solution

The recently added xrdb call in [YaST2.call](https://github.com/yast/yast-installation/blob/master/startup/YaST2.call#L95) does not work since xrdb is missing.

Add it.

Note that the xrdb package depends on cpp which we don't need here.