### PR TITLE
support leap port of armv7hl (bsc#1198302)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -68,7 +68,11 @@ ExclusiveArch:  do_not_build
 %if "%{the_version}" == ""
 %error "bad version string"
 %endif
+%ifarch %arm
+%define net_repo https://download.opensuse.org/ports/%{the_arch}/distribution/leap/%{the_version}/repo/oss
+%else
 %define net_repo https://download.opensuse.org/distribution/leap/%{the_version}/repo/oss
+%endif
 %else
 %define with_exfat 1
 %ifarch %arm aarch64 ppc64 ppc64le


### PR DESCRIPTION
bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1198302

Issue: wrong URL is used for net installer for iso on armv7hl

Solution: Adapt spec file to point to correct url for this architecture.