### PR TITLE
use parse-zdev.sh from s390-tools for device activation (bsc#1198326)

### DIFF
--- a/data/initrd/scripts/device_auto_config
+++ b/data/initrd/scripts/device_auto_config
@@ -2,7 +2,11 @@
 
 exec >&2
 
-# s390x: I/O device pre-configuration (jsc#SLE-7396)
-if [ -x /sbin/chzdev -a -e /sys/firmware/sclp_sd/config/data ] ; then
-  /sbin/chzdev --import /sys/firmware/sclp_sd/config/data
+# dummy definition to make parse-zdev.sh happy
+# 'rd.zdev=no-auto' case is handled in linuxrc
+getargs () { true ; }
+
+# s390x: I/O device pre-configuration (jsc#SLE-7396, bsc#1198326)
+if [ -x /usr/lib/dracut/modules.d/95zdev/parse-zdev.sh ] ; then
+  . /usr/lib/dracut/modules.d/95zdev/parse-zdev.sh
 fi


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/589 to SLE15-SP4.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1198326
- https://trello.com/c/QceHWuzq

The installer initial RAM-disk is missing startup-logic to perform PCI auto-activation.

## Solution

Use `parse-zdev.sh` provided by s390-tools for dracut to perform the device activation.