### PR TITLE
fix typo (bsc#1198326)

### DIFF
--- a/data/initrd/scripts/device_auto_config
+++ b/data/initrd/scripts/device_auto_config
@@ -7,6 +7,6 @@ exec >&2
 getargs () { true ; }
 
 # s390x: I/O device pre-configuration (jsc#SLE-7396, bsc#1198326)
-if -x [ /usr/lib/dracut/modules.d/95zdev/parse-zdev.sh ] ; then
+if [ -x /usr/lib/dracut/modules.d/95zdev/parse-zdev.sh ] ; then
   . /usr/lib/dracut/modules.d/95zdev/parse-zdev.sh
 fi


### PR DESCRIPTION
## Task

https://github.com/openSUSE/installation-images/pull/589 contained a typo. Fix it.