### PR TITLE
Adjust to ignore all python 3.x versions

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -104,7 +104,6 @@ nfsidmap: ignore
 pam-config: ignore
 permissions: ignore
 pinentry: ignore
-python2-setuptools: ignore
 sessreg: ignore
 shared-mime-info: ignore
 update-alternatives: ignore
@@ -207,15 +206,15 @@ p11-kit:
 
 novnc:
 python38-setuptools: ignore
+python310-setuptools: ignore
 
 add_all skelcd-fallbackrepo-.*:
 
-python38-websockify:
-
-# normally python38-websockify would require python38-numpy but the
+# normally python3X-websockify would require python3X-numpy but the
 # dependency is actually optional in the code - so avoid it to
 # save **a lot** of space
 python38-numpy: ignore
+python310-numpy: ignore
 
 vim-small:
 


### PR DESCRIPTION
* The websockify dependency is not needed as it is required by novnc,
which is already listed.

* Remove python2-* stuff as that is no longer built in tumbleweed

* Ignore all the numpy versions to be futureproof.