### PR TITLE
pam config moved to /usr/lib/pam.d

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -257,7 +257,9 @@ ntfs-3g:
 
 pam:
   /
-  if exists(pam, /usr/etc/pam.d/common-auth)
+  if exists(pam, /usr/lib/pam.d/common-auth)
+    pam_common_auth = /usr/lib/pam.d/common-auth
+  elsif exists(pam, /usr/etc/pam.d/common-auth)
     pam_common_auth = /usr/etc/pam.d/common-auth
   else
     pam_common_auth = /etc/pam.d/common-auth

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -345,7 +345,11 @@ krb5:
   /usr/lib*/libk5crypto.so.*
 
 pam:
-  /usr/etc/pam.d
+  if exists(pam, /usr/lib/pam.d)
+    /usr/lib/pam.d
+  else
+    /usr/etc/pam.d
+  endif
   /etc
   /usr/lib*/security
   /usr/lib*/libpam.so.*


### PR DESCRIPTION
## Task

- https://build.opensuse.org/request/show/984917

pam config files have been moved to `/usr/lib/pam.d`. Adjust locations.