### PR TITLE
add edid-write tool to create EDID data (bsc#1199020)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -122,6 +122,7 @@ linuxrc:
   else
     m /usr/sbin/linuxrc /init
   endif
+  /usr/bin/edid-write
   s /lbin/extend /bin
   d /etc/linuxrc.d
 

--- a/gefrickel
+++ b/gefrickel
@@ -61,6 +61,8 @@ rm -rf a b
 # lib vs. lib64
 lib_dir=usr/lib
 mkdir -p "b/$lib_dir"
+# ensure firmware dir stays writable
+mkdir -p "b/$lib_dir/firmware"
 # for usrmerge
 if [ -e  "$lib_dir/modules" ]; then
   mv "$lib_dir/modules" "b/$lib_dir"


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1199020

Add `edid-write` tool to installation system. Also, ensure `/usr/lib/firmware` is writable as this is where the generated firmware blob is stored.

This completes https://github.com/openSUSE/linuxrc/pull/297.