### PR TITLE
limit LeapMicro building

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -102,7 +102,10 @@ ExclusiveArch:  do_not_build
 %endif
 
 %if "%flavor" == "LeapMicro"
+# build only on Leap
+%if 0%{?is_opensuse} && 0%{?sle_version}
 %define theme LeapMicro
+%endif
 %endif
 
 %if "%flavor" == "MicroOS"


### PR DESCRIPTION
## Task

`LeapMicro` flavor should not always be built. Only for Leap.