### PR TITLE
limit LeapMicro building

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -104,7 +104,10 @@ ExclusiveArch:  do_not_build
 %endif
 
 %if "%flavor" == "LeapMicro"
+# build only on Leap
+%if 0%{?is_opensuse} && 0%{?sle_version}
 %define theme LeapMicro
+%endif
 %endif
 
 %if "%flavor" == "MicroOS"


### PR DESCRIPTION
## Task

`LeapMicro` flavor should not always be built. Only for Leap.

## See also

This is a port of https://github.com/openSUSE/installation-images/pull/604 to SLE15-SP4.
