### PR TITLE
fix Bengali font issue: switch from MuktiNarrow.ttf to Mukti.ttf (bsc#1202083, bsc#1197977)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -547,7 +547,7 @@ efont-unicode-bitmap-fonts:
 
 # various asiatic & arabic fonts
 indic-fonts:
-  /usr/share/fonts/truetype/MuktiNarrow.ttf
+  /usr/share/fonts/truetype/Mukti.ttf
   /usr/share/fonts/truetype/Lohit-Gujarati.ttf
   /usr/share/fonts/truetype/Lohit-Devanagari.ttf
   /usr/share/fonts/truetype/Lohit-Marathi.ttf


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1202083

Bengali text is not shown correctly as no appropriate font is available.

This is a result of [bsc#1197977](https://bugzilla.suse.com/show_bug.cgi?id=1197977) which removed MuktiNarrow.

## Solution

Use Mukti instead if MuktiNarrow.