### PR TITLE
Allow shadow to put pam files to /usr/lib/pam.d

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -379,8 +379,12 @@ nscd:
   R s/(enable-cache\s+(passwd|group)\s+)yes/$1no/g /etc/nscd.conf
 
 shadow:
+  if exists(shadow, /usr/lib/pam.d)
+    /usr/lib/pam.d
+  else
+    /usr/etc/pam.d
+  endif
   /etc
-  /usr/etc
   /usr/bin
   /usr/sbin/pwunconv
   /usr/sbin/chpasswd


### PR DESCRIPTION
Fixes issue #607
