### PR TITLE
require glibc-locale explicitly

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -355,6 +355,7 @@ BuildRequires:  gamin-server
 BuildRequires:  gdb
 BuildRequires:  gettext-runtime-mini
 BuildRequires:  glibc-i18ndata
+BuildRequires:  glibc-locale
 BuildRequires:  gpart
 BuildRequires:  gpg2
 BuildRequires:  gpm


### PR DESCRIPTION
## Problem

Due to a libyui dependency change glibc-locale is no longer implicitly added.

## Solution

Add glibc-locale to BuildRequires.