### PR TITLE
shadow & /usr/lib/pam.d: fix also initrd

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -344,7 +344,11 @@ nscd:
 
 shadow:
   /etc
-  /usr/etc
+  if exists(shadow, /usr/lib/pam.d)
+    /usr/lib/pam.d
+  else
+    /usr/etc/pam.d
+  endif
   /usr/sbin/groupadd
   /usr/sbin/useradd
   /usr/sbin/useradd.local

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -143,8 +143,9 @@ if exists(samba-client-libs)
     /usr/lib*/libwbclient.*
 else
   samba-libs: nodeps
+    /usr/lib*/samba/libwinbind-client-samba4.so
 endif
-    /usr/lib*/samba/lib{replace,winbind-client,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
+    /usr/lib*/samba/lib{replace,genrand,samba-debug,socket-blocking,sys-rw,time-basic,iov-buf}-samba4.so
 
 # for samba-libs
 libgnutls*:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -196,7 +196,7 @@ if exists(wpa_supplicant)
 
   wireless-tools:
     /usr/sbin
-    /etc
+    /usr/lib
     r /usr/sbin/switch_prism_driver
     r /usr/sbin/install_acx100_firmware
     r /usr/sbin/install_intersil_firmware

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -468,9 +468,6 @@ endif
 gpm:
   /usr/sbin/gpm
 
-xdm:
-  /etc/X11/xdm/Keyboard.map
-
 rgb:
   /usr/share/X11/rgb.txt
 


### PR DESCRIPTION
## Task

Fix some usrmove related issues:

- shadow: fix /usr/lib/pam.d inclusion also in initrd
- xdm: Keyboard.map no longer exists (and is also no longer needed)
- wireless-tools: /etc -> /usr/lib
- samba-client-libs: there is no libwinbind-client-samba4 (but libwbclient)