### PR TITLE
etc: update module.config to match 6.1

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -195,6 +195,7 @@ kernel/drivers/i2c/.*
 kernel/drivers/leds/.*
 kernel/drivers/mailbox/.*
 kernel/drivers/md/.*
+kernel/drivers/net/pse-pd/.*
 kernel/drivers/nvdimm/.*
 kernel/drivers/nvme/.*
 kernel/drivers/pci/controller/.*


### PR DESCRIPTION
6.1 brought a new group in networkintg: Power Sourcing Equipment. Add it all to the other list as the modules are very specific modules to be built into installation images.