### PR TITLE
systemd lib moved to /usr/lib64

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -399,7 +399,7 @@ systemd:
   /usr/lib/systemd/systemd-vconsole-setup
   /usr/bin/systemd-detect-virt
   /usr/lib/systemd/systemd-sysctl
-  /usr/lib/systemd/*.so
+  /usr/lib*/systemd/*.so
   # plymouth is not working if we include all rules - no idea why
   /usr/lib/udev/rules.d/99-systemd.rules
   # needed to ensure it's writable


### PR DESCRIPTION
## Task

`libsystemd-core-N.so` and  `libsystemd-shared-N.so` moved from `/usr/lib/systemd` to `/usr/lib64/systemd`.