### PR TITLE
always redirect udev log output to /var/log/udev.log (bsc#1204216)

### DIFF
--- a/data/initrd/scripts/udev_setup
+++ b/data/initrd/scripts/udev_setup
@@ -35,10 +35,13 @@ fi
 # start udevd
 echo -n "Starting udevd "
 if [ -n "$linuxrc_debug" ] ; then
-  udevd --daemon --debug 2>/var/log/udev.log
+  udev_opt=--debug
 else
-  udevd --daemon
+  udev_opt=
 fi
+
+echo "# boot with udev.log_level=debug or linuxrc.debug=1 to get udev debug output logged here" >/var/log/udev.log
+udevd --daemon $udev_opt 2>>/var/log/udev.log
 
 # create devices (cf. bsc#1084357)
 /usr/bin/udevadm trigger --type=subsystems --action=add


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1204216

It is not clear how to enable udev debug output in the installation system.

## Solution

- always log udev output to `/var/log/udev.log`
- include hint about how to enable udev debug output in `/var/log/udev.log`

udev debug output can be enabled either with `linuxrc.debug=1` or `udev.log_level=debug`. Both cases log to `/var/log/udev.log`.