### PR TITLE
switch from curl to osc api to avoid authentication hassle with IBS

### DIFF
--- a/doc/configoptions.md
+++ b/doc/configoptions.md
@@ -80,6 +80,12 @@ use this to find out actual usage:
   It is similar to RPM BuildRoot as it holds the file tree in the unpacked
   state just before being packaged (see FS) in the IMAGE.
 
+- ignore_packages=package1,package2,...
+
+  List of packages that should always be ignored. Useful for resolving package ambiguities.
+
+  Only valid when building outside OBS.
+
 <!-- old -->
 
 - debug=DEBUG (comma separated tags, eg. `solv`, `filedeps`, `ignore`,

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -765,6 +765,7 @@ sub resolve_deps_obs
   print $f "#!BuildIgnore: simple_expansion_hack\nName: foo\n";
   print $f "BuildRequires: $_\n" for (@$packages);
   print $f "#!BuildIgnore: $_\n" for (@$ignore);
+  print $f "#!BuildIgnore: $_\n" for (split /,/, $ENV{ignore_packages});
   close $f;
 
   my %p;


### PR DESCRIPTION
## Tasks

1. There's no point in reimplementing the IBS authentication procedure. Use `osc api` instead of `curl` to access the OBS backend.
2. Some projects rely on specific project configs to prefer some packages over others. Add new `ignore_packages` environment variable to resolve ambiguities manually to allow local builds outside OBS.