### PR TITLE
support more general wicked firmware devices interface (jsc#PED-3118, jsc#PED-967)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -95,6 +95,7 @@ netcfg:
 nvme-cli:
 sed:
 ?wicked:
+?wicked-nbft:
 ?s390-tools-hmcdrvfs:
 rsyslog:
 sysconfig-netconfig:

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -74,11 +74,42 @@ if [ -x usr/sbin/wickedd ] ; then
   } 2>/var/log/wickedd.log
 fi
 
-# gather list of ibft interfaces for linuxrc
-ibft=
-while read ifname xxx ; do
-  [ -z "$ifname" ] && continue
-  [ -n "$ibft" ] && ibft="$ibft",
-  ibft="$ibft$ifname"
-done < <(/etc/wicked/extensions/ibft -l)
-echo "ibftdevices: $ibft" >/etc/ibft_devices
+# New wicked: gather list of firmware interfaces for linuxrc.
+#
+# Parse lines like: 'fw_type interface_1 interface_2 ...' and store a
+# comma-separated list of all interfaces and types in:
+#
+# /etc/firmware_devices (interface list)
+# /etc/firmware_types (type list)
+#
+fw_types=
+fw_interfaces=
+while read -a fw ; do
+  fw_types="$fw_types,${fw[0]}"
+  unset fw[0]
+  for i in ${fw[@]} ; do
+    fw_interfaces="$fw_interfaces,$i"
+  done
+done < <(wicked firmware interfaces 2>/dev/null)
+
+fw_types=${fw_types#,}
+fw_interfaces=${fw_interfaces#,}
+
+if [ -n "$fw_interfaces" ] ; then
+  echo "firmwaredevices: $fw_interfaces" >/etc/firmware_devices
+fi
+
+if [ -n "$fw_types" ] ; then
+  echo "firmwaretypes: $fw_types" >/etc/firmware_types
+fi
+
+if [ ! -f /etc/firmware_devices ] ; then
+  # Old wicked: gather list of ibft interfaces for linuxrc.
+  ibft=
+  while read ifname xxx ; do
+    [ -z "$ifname" ] && continue
+    [ -n "$ibft" ] && ibft="$ibft",
+    ibft="$ibft$ifname"
+  done < <(/etc/wicked/extensions/ibft -l)
+  echo "ibftdevices: $ibft" >/etc/ibft_devices
+fi

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -521,6 +521,7 @@ BuildRequires:  valgrind
 BuildRequires:  vim-small
 BuildRequires:  wget
 BuildRequires:  wicked
+BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools
 %ifnarch s390 s390x
 BuildRequires:  wpa_supplicant


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/PED-967
- https://jira.suse.com/browse/PED-3118

wicked now has a more general extension that lists firmware handled network interfaces (not just ibft).

Gather list of firmware handled interfaces to be used by linuxrc.

## See also

- https://github.com/openSUSE/linuxrc/pull/310