### PR TITLE
support 32-bit UEFI firmware on x86_64/i386 (bsc#1208003, jsc#PED-2569)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ COMMON_TARGETS	     := rescue root root+rescue bind libstoragemgmt gdb libyui-re
 COMMON_INSTSYS_PARTS := config rpmlist root common rescue bind libstoragemgmt gdb libyui-rest-api
 
 ifneq ($(filter i386, $(ARCH)),)
-ALL_TARGETS   := initrd-themes initrd boot boot-themes $(COMMON_TARGETS) zenroot
+ALL_TARGETS   := initrd-themes initrd boot-grub2-efi boot boot-themes $(COMMON_TARGETS) zenroot
 INSTSYS_PARTS := $(COMMON_INSTSYS_PARTS)
-BOOT_PARTS    := boot/* initrd
+BOOT_PARTS    := boot/* initrd efi
 endif
 
 ifneq ($(filter x86_64, $(ARCH)),)

--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -3,6 +3,9 @@ d /EFI/BOOT
 if arch eq 'x86_64'
   grub_target = x86_64
   boot_efi = x64
+elsif arch eq 'i386'
+  grub_target = i386
+  boot_efi = ia32
 elsif arch eq 'aarch64'
   grub_target = arm64
   boot_efi = aa64
@@ -24,7 +27,7 @@ x grub-efi.cfg EFI/BOOT/grub.cfg
 R s/\@arch\@/<arch>/g EFI/BOOT/grub.cfg
 
 # kernel & initrd are in a different dir on x86_64
-if arch eq 'x86_64'
+if arch eq 'x86_64' || arch eq 'i386'
   R s/(\/(linux|initrd))/\/loader$1/g EFI/BOOT/grub.cfg
 endif
 
@@ -37,6 +40,12 @@ R s/<([a-z_0-9]+)>.*?<\/\1>\n//sg EFI/BOOT/grub.cfg
 
 grub2-<grub_target>-efi:
   a <grub_efi> EFI/BOOT/boot<boot_efi>.efi
+
+# dual 32 bit and 64 bit bootable
+if arch eq 'x86_64'
+  ?grub2-i386-efi:
+    a usr/share/grub2/i386-efi/grub.efi EFI/BOOT/bootia32.efi
+endif
 
 # use shim if available
 if exists(shim)

--- a/data/boot/theme.file_list
+++ b/data/boot/theme.file_list
@@ -29,7 +29,7 @@ if arch eq 'i386' || arch eq 'x86_64'
 endif
 
 
-if arch eq 'x86_64' || arch eq 'aarch64' || arch eq 'armv7l' || arch eq 'armv6l' || arch eq 'riscv64'
+if arch eq 'i386' || 'x86_64' || arch eq 'aarch64' || arch eq 'armv7l' || arch eq 'armv6l' || arch eq 'riscv64'
   # grub2-efi with graphics
   # grub.cfg is patched in grub2-efi.file_list
   if 1

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -604,6 +604,10 @@ BuildRequires:  shim
 BuildRequires:  efibootmgr
 #!BuildIgnore:  glibc-32bit
 %endif
+%ifarch %ix86
+BuildRequires:  grub2-i386-efi
+BuildRequires:  efibootmgr
+%endif
 %ifarch ia64
 BuildRequires:  acpica
 BuildRequires:  dmidecode


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/PED-2569
- https://bugzilla.suse.com/show_bug.cgi?id=1208003

Make installation media  bootable with 32-bit UEFI firmware.

## Notes

This has two effects:

1. The i386 Tumbleweed installation media are now  bootable on 32-bit UEFI systems.
2. The x86_64 Tumbleweed media **would** be bootable on 32-bit UEFI systems once the `grub2-i386-efi` package has been made available on x86_64 (it currently is not).

No change in our tooling chain is needed for this (I think).

The patch does **not** add support for 32-bit UEFI in our installer YaST. The installed system might not be bootable unless you manually adjust it. Running `pbl --install` once should do the trick (assuming you have created an EFI system partition).