### PR TITLE
move open-iscsi into initrd to ensure config files are writable (bsc#1207374)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -97,6 +97,7 @@ lsscsi:
 mdadm:
 netcfg:
 nvme-cli:
+open-iscsi:
 sed:
 ?wicked:
 ?wicked-nbft:
@@ -249,11 +250,6 @@ ncurses-utils:
 iproute2:
   /usr/bin/ip
   /usr/sbin/ip
-
-open-iscsi:
-  # must be writable
-  /etc/iscsi
-  c 644 0 0 /etc/iscsi/iscsid.conf
 
 util-linux:
   /usr/sbin/mkswap

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -170,7 +170,6 @@ libyui-qt-graph*:
 lvm2:
 multipath-tools:
 ntfsprogs:
-open-iscsi:
 openslp:
 openslp-server:
 ?pam-modules:


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1207374

iscsi config has been partially moved from `/etc/iscsi` to `/var/lib/iscsi`.

To avoid further trouble, add entire `open-iscsi` package to initrd (Not just the config in `/etc`).