### PR TITLE
use grub2-i386-efi package on x86_64 (bsc#1208057)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -601,10 +601,9 @@ BuildRequires:  grub2-x86_64-efi
 %if %with_shim
 BuildRequires:  shim
 %endif
-BuildRequires:  efibootmgr
 #!BuildIgnore:  glibc-32bit
 %endif
-%ifarch %ix86
+%ifarch %ix86 x86_64
 BuildRequires:  grub2-i386-efi
 BuildRequires:  efibootmgr
 %endif


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1208057
- https://github.com/openSUSE/installation-images/pull/623

Since `grub2-i386-efi` is now available on x86_64: adjust spec file to make use of it.