### PR TITLE
clean up Xorg config (bsc#1192678, bsc#1207516)

### DIFF
--- a/data/root/etc/xorg.conf.template
+++ b/data/root/etc/xorg.conf.template
@@ -1,46 +1,24 @@
 Section "Device"
-  Identifier "vboxvideo"
-  Driver  "vboxvideo"
-EndSection
-
-Section "Screen"
-  Identifier "vboxvideo"
-  Device "vboxvideo"
-EndSection
-
-
-Section "Device"
-  Identifier "vmware"
-  Driver  "vmware"
-EndSection
-
-Section "Screen"
-  Identifier "vmware"
-  Device "vmware"
-EndSection
-
-
-Section "Device"
   Identifier "modesetting"
   Driver  "modesetting"
   Option "PreferCloneMode" "true"
   Option "AccelMethod" "none"
 EndSection
+
 Section "Screen"
   Identifier "modesetting"
   Device "modesetting"
 EndSection
 
-
 Section "Device"
   Identifier "fbdev"
   Driver  "fbdev"
 EndSection
+
 Section "Screen"
   Identifier "fbdev"
   Device "fbdev"
 EndSection
-
 
 Section "Device"
   Identifier "vesa"
@@ -52,11 +30,8 @@ Section "Screen"
   Device "vesa"
 EndSection
 
-
 Section "ServerLayout"
   Identifier "Layout"
-  Screen  "vboxvideo"
-  Screen  "vmware"
   Screen  "modesetting"
   Screen  "fbdev"
   Screen  "vesa"


### PR DESCRIPTION
## Tasks

- https://bugzilla.suse.com/show_bug.cgi?id=1192678
- https://bugzilla.suse.com/show_bug.cgi?id=1207516

Xorg config was using obsolete drivers. Clean up config to essentially rely on kernel drm for video mode setup (with vesa fallback on x86).

## See also

This ports https://github.com/openSUSE/installation-images/pull/543 to SLE15-SP5.