### PR TITLE
messagebus user is now created in dbus-1-common (bsc#1208803)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -462,6 +462,11 @@ dbus-1:
   r /usr/bin/dbus-launch*
   E prein
 
+# prein script for messagebus user
+dbus-1-common:
+  /
+  E prein
+
 # For FIPS installation:
 
 ?libopenssl*_*-hmac:


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1208803

dbus not working properly after dbus package re-structuring.

## Solution

Probably the missing `messagebus` user. It's now created in `prein` in `dbus-1-common`.