### PR TITLE
add mt to rescue system (bsc#1188998)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -121,6 +121,7 @@ bzip2:
 checkmedia:
 cifs-utils:
 cpio:
+cpio-mt:
 cracklib-dict-full:
 cracklib:
 cryptsetup:


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1188998

Add `mt` to rescue system.