### PR TITLE
fix minor usrmerge issue

### DIFF
--- a/data/initrd/modules.file_list
+++ b/data/initrd/modules.file_list
@@ -1,5 +1,6 @@
 # for depmod; also to indicate usrmerge in "gefrickel" script
-s usr/lib lib
+# don't use 's usr/lib lib' as link might already exist
+e ln -snf usr/lib lib
 
 d usr/lib/modules/<kernel_ver>
 d usr/lib/modules/<kernel_ver>/initrd


### PR DESCRIPTION
## Problem

The last patch set leads to the creation of a `/usr/lib/lib -> usr/lib` symlink.

Doesn't have any bad side effects but is not correct anyway.