### PR TITLE
add qrtr* kernel modules (bsc#1209965)

### DIFF
--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -29,7 +29,7 @@ for $m (sort keys %fw) {
     for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw>) {
       if(-r $f) {
         $f =~ s#^$fw_dir/##;
-        system "install -m 644 -D $fw_dir/$f lib/firmware/$f\n";
+        system "install -m 644 -D '$fw_dir/$f' 'lib/firmware/$f'\n";
         $ok = 1;
       }
     }

--- a/etc/module.config
+++ b/etc/module.config
@@ -346,6 +346,7 @@ kernel/net/9p/.*
 kernel/net/ieee802154/.*
 kernel/net/ipv4/.*
 kernel/net/mac802154/.*
+kernel/net/qrtr/.*
 
 
 [WLAN]

--- a/etc/module.list
+++ b/etc/module.list
@@ -129,6 +129,7 @@ kernel/net/802/garp.ko
 kernel/net/802/stp.ko
 kernel/net/802/mrp.ko
 kernel/net/llc/
+kernel/net/qrtr
 
 kernel/drivers/power/power_supply.ko
 kernel/drivers/firmware/


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1209965

Add `qrtr` and `qrtr-*` kernel modules.

## Bonus

Firmware files with spaces in their file name were not added correctly. Fix that. Typical example:

`brcmfmac43455-sdio.Raspberry Pi Foundation-Raspberry Pi 4 Model B.txt`

## See also

This ports part of https://github.com/openSUSE/installation-images/pull/643 to SLE15-SP5.