### PR TITLE
etc: update module.config to match 6.4

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -128,6 +128,7 @@ bcma
 caif_hsi
 ptp
 ptp_clockmatrix
+ptp_dfl_tod
 ptp_dte
 ptp_idt82p33
 ptp_kvm


### PR DESCRIPTION
6.4 brought a new `ptp` module: `ptp_dfl_tod`. Put it along other `ptp` modules to the `[other]` section.