### PR TITLE
usrmerge: Fix build with usrmerged kernel modules (boo#1211796)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ initrd+modules: base
 	theme=$(THEMES) image=modules-config src=initrd fs=none bin/mk_image
 	theme=$(THEMES) bin/mlist1
 	theme=$(THEMES) bin/mlist2
-	rm -rf tmp/initrd/modules tmp/initrd/lib/modules
+	rm -rf tmp/initrd/modules tmp/initrd/lib/modules tmp/initrd/usr/lib/modules
 	theme=$(THEMES) mode=add tmpdir=initrd image=modules src=initrd fs=none bin/mk_image
 	theme=$(THEMES) mode=add tmpdir=initrd image=digests src=initrd fs=none bin/mk_image
 	mkdir -p images/module-config/$${MOD_CFG:-default}
@@ -119,7 +119,7 @@ initrd+modules+gefrickel: base
 	theme=$(THEMES) image=modules-config src=initrd fs=none bin/mk_image
 	theme=$(THEMES) bin/mlist1
 	theme=$(THEMES) bin/mlist2
-	rm -rf tmp/initrd/modules tmp/initrd/lib/modules tmp/initrd_gefrickel
+	rm -rf tmp/initrd/modules tmp/initrd/lib/modules tmp/initrd/usr/lib/modules tmp/initrd_gefrickel
 	# work on a copy to not modify the origial tree
 	cp -a tmp/initrd tmp/initrd_gefrickel
 	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=modules src=initrd fs=none bin/mk_image

--- a/bin/kernel_mods
+++ b/bin/kernel_mods
@@ -10,7 +10,7 @@ for $rpm (@ARGV) {
   $archs{$arch} = 1;
 
   for (@files) {
-    if(m#^/lib/modules/.*/([^/]+)\.ko#) {
+    if(m#^(/usr)?/lib/modules/.*/([^/]+)\.ko#) {
       $mod->{$1}{$arch} = 1;
     }
   }

--- a/bin/mlist1
+++ b/bin/mlist1
@@ -85,7 +85,7 @@ for (@ml_all) {
   my ($m, $p);
   my $y = 1;
 
-  s#^/lib/modules/[^/]+/##;
+  s#^(/usr)?/lib/modules/[^/]+/##;
   if(/^(\S+):/) {
     $m = $1;
   }

--- a/data/initrd/modules-config.file_list
+++ b/data/initrd/modules-config.file_list
@@ -3,13 +3,14 @@
   # generate modules.alias, modules.dep
   if exists(<kernel_rpm>, <kernel_module_dir>/<kernel_ver>/System.map)
     L <kernel_module_dir>/<kernel_ver>/System.map System.map
-    L usr/lib .
+    e mkdir -p usr
+    L usr/lib usr
   else
     L lib .
     L boot/System.map* System.map
   endif
   e /sbin/depmod -a -b . -F System.map <kernel_ver>
-  e cp lib/modules/<kernel_ver>/modules.dep .
-  e find lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.zst' | xargs modinfo >modules.info
-  r System.map lib
+  e cp .<kernel_module_dir>/<kernel_ver>/modules.dep .
+  e find .<kernel_module_dir>/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.zst' | sed -e 's#^[.]/##' | xargs modinfo >modules.info
+  r System.map usr lib
 

--- a/etc/mkinstallinitrd
+++ b/etc/mkinstallinitrd
@@ -48,6 +48,13 @@ die "base file \"$opt_base.xz\" missing\n" unless -f "$lib_dir/$opt_base.xz";
 mkdir "$tmp_dir/i", 0755;
 
 my $kernel_dir = "";
+my $kernel_module_dir = "";
+
+if ( -d "$kernel_dir/usr/lib/modules/") {
+  $kernel_module_dir = "/usr/lib/modules";
+} else {
+  $kernel_module_dir = "/lib/modules";
+}
 
 if(defined $opt_kernel_rpm) {
   my $opt_kernel_base = $opt_kernel_rpm;
@@ -62,7 +69,13 @@ if(defined $opt_kernel_rpm) {
   system "cd $tmp_dir/k; rpm2cpio $opt_kernel_rpm | cpio --quiet --extract --unconditional --preserve-modification-time --make-directories";
   $kernel_dir = "$tmp_dir/k";
 
-  $_ = <$kernel_dir/lib/modules/*/kernel>;
+  if ( -d "$kernel_dir/usr/lib/modules/") {
+    $kernel_module_dir = "/usr/lib/modules";
+  } else {
+    $kernel_module_dir = "/lib/modules";
+  }
+
+  $_ = <$kernel_dir$kernel_module_dir/*/kernel>;
 
   if(m#/lib/modules/(.*?)/kernel#) {
     $opt_kernel = $1;
@@ -95,10 +108,11 @@ chomp (my @modules = (<F>));
 close F;
 
 my @mod_files;
+my $noslash_kernel_module_dir = substr($kernel_module_dir, 0, -1);
 
-if(-d "$kernel_dir/lib/modules/$opt_kernel-$opt_kernel_style") {
+if(-d "$kernel_dir$kernel_module_dir/$opt_kernel-$opt_kernel_style") {
   for (@modules) {
-    push @mod_files, scalar(`cd $kernel_dir/ ; find lib/modules/$opt_kernel-$opt_kernel_style/{updates,weak-updates,extra,} -name $_ 2>/dev/null | head -n 1`);
+    push @mod_files, scalar(`cd $kernel_dir/ ; find $noslash_kernel_module_dir/$opt_kernel-$opt_kernel_style/{updates,weak-updates,extra,} -name $_ 2>/dev/null | head -n 1`);
   }
 }
 
@@ -108,15 +122,15 @@ chomp @mod_files;
 
 warn "warning: no modules\n" if @mod_files == 0;
 
-system "mkdir -p $tmp_dir/i/lib/modules/$override/initrd $tmp_dir/i/lib/modules/$opt_kernel-$opt_kernel_style";
-symlink "../$override", "$tmp_dir/i/lib/modules/$opt_kernel-$opt_kernel_style/updates";
-symlink "lib/modules/$override/initrd", "$tmp_dir/i/modules";
+system "mkdir -p $tmp_dir/i$kernel_module_dir/$override/initrd $tmp_dir/i$kernel_module_dir/$opt_kernel-$opt_kernel_style";
+symlink "../$override", "$tmp_dir/i$kernel_module_dir/$opt_kernel-$opt_kernel_style/updates";
+symlink "$noslash_kernel_module_dir/$override/initrd", "$tmp_dir/i/modules";
 
 for (@mod_files) {
-  system "cd $kernel_dir/ ; cp -a '$_' $tmp_dir/i/lib/modules/$override/initrd";
+  system "cd $kernel_dir/ ; cp -a '$_' $tmp_dir/i$kernel_module_dir/$override/initrd";
 }
 
-my $system_map = "$kernel_dir/lib/modules/System.map-$opt_kernel-$opt_kernel_style";
+my $system_map = "$kernel_dir$kernel_module_dir/System.map-$opt_kernel-$opt_kernel_style";
 $system_map = "$kernel_dir/boot/System.map-$opt_kernel-$opt_kernel_style" unless -f $system_map;
 die "no kernel symbols\n" unless -f $system_map;
 


### PR DESCRIPTION
With depmod searching for modules in /usr/lib existing installation scripts fail. This requires the updated kmod.