### PR TITLE
latest kmod package finally works with /usr/lib (bsc#1211796)

### DIFF
--- a/data/initrd/modules-config.file_list
+++ b/data/initrd/modules-config.file_list
@@ -3,13 +3,14 @@
   # generate modules.alias, modules.dep
   if exists(<kernel_rpm>, <kernel_module_dir>/<kernel_ver>/System.map)
     L <kernel_module_dir>/<kernel_ver>/System.map System.map
-    L usr/lib .
+    d usr
+    L usr/lib usr
+    s usr/lib lib
   else
     L lib .
     L boot/System.map* System.map
   endif
   e /sbin/depmod -a -b . -F System.map <kernel_ver>
-  e cp lib/modules/<kernel_ver>/modules.dep .
-  e find lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.zst' | xargs modinfo >modules.info
-  r System.map lib
-
+  e cp usr/lib/modules/<kernel_ver>/modules.dep .
+  e find usr/lib/modules/<kernel_ver> -name '*.ko' -o -name '*.ko.xz' -o -name '*.ko.zst' | xargs modinfo >modules.info
+  r System.map lib usr


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1211796

The latest kmod package finally uses `/usr/lib` instead of `/lib` to look for kernel modules.

Adjust module config script to work also with this variant.

## See also

This replaces https://github.com/openSUSE/installation-images/pull/647.