### PR TITLE
add shim and grub2-i386-efi to rescue system (bsc#1209985)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -96,12 +96,15 @@ binutils: ignore
 ?efibootmgr:
 ?elilo:
 ?grub2-i386-pc:
+?grub2-i386-efi:
 ?grub2-x86_64-efi:
 ?grub2-arm64-efi:
 ?grub2-arm-efi:
 ?grub2-powerpc-ieee1275:
 ?grub2-riscv64-efi:
 ?grub2:
+?shim:
+?mokutil:
 ?hyper-v:
 ?iprutils:
 ?pdisk:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -601,6 +601,7 @@ BuildRequires:  tftp
 BuildRequires:  grub2-x86_64-efi
 %if %with_shim
 BuildRequires:  shim
+BuildRequires:  mokutil
 %endif
 #!BuildIgnore:  glibc-32bit
 %endif


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1209985

Would be nice to have `mokutil` in rescue system.

## Solution

Add `shim` and `mokutil` packages to rescue system. 

## Bonus

Add also `grub2-i386-efi` if available since we do support UEFI 32-bit on x86 meanwhile.