### PR TITLE
Drop dependency on Leap-Micro-release-dvd for LeapMicro

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -200,7 +200,8 @@ BuildRequires:  distribution-logos-openSUSE-Kubic
 %define branding_skelcd   SMO
 %define branding_systemd  SMO
 %if "%theme" == "LeapMicro"
-BuildRequires:  Leap-Micro-release Leap-Micro-release-dvd
+BuildRequires:  Leap-Micro-release
+BuildRequires:  distribution-logos-openSUSE-LeapMicro
 %define branding_plymouth openSUSE
 %define branding_grub2    openSUSE
 %define branding_gfxboot  openSUSE


### PR DESCRIPTION
Hello,

this is a change that we have been using in our LeapMicro 5.X spec for quite some time, SLEM 5.5 installation images fail on `nothing provides Leap-Micro-release-dvd`

See https://build.opensuse.org/package/view_file/openSUSE:Leap:Micro:5.4/installation-images/installation-images.spec?expand=1


