### PR TITLE
add reset-rzg2l-usbphy-ctrl module (bsc#1213805)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -180,6 +180,8 @@ virtio_scsi
 
 tegra20-apb-dma
 
+reset-rzg2l-usbphy-ctrl
+
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-
 kernel/crypto/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -269,6 +269,8 @@ kernel/drivers/mmc/host/sdhci-iproc.ko
 kernel/drivers/gpio/gpio-raspberrypi-exp.ko
 kernel/drivers/net/mdio/mdio-bcm-unimac.ko
 
+kernel/drivers/reset/reset-rzg2l-usbphy-ctrl.ko
+
 # kmps
 updates/
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1213805

Add reset-rzg2l-usbphy-ctrl module (needed on aarch64).