### PR TITLE
 Add system-user-lp to initrd. group(lp) moved from system-group-hardware there (bsc#1214467)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -482,6 +482,10 @@ system-group-hardware:
   /
   E prein
 
+system-user-lp:
+  /
+  E prein
+
 udev:
   /
   E prein

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -309,6 +309,7 @@ s /usr/bin/true /sbin/mkinitrd_setup
 
 system-group-hardware:
 system-group-kvm:
+system-user-lp:
 system-user-nobody:
 
 rpm:


### PR DESCRIPTION
Run the prein script to have the user/group generated
