### PR TITLE
cifs kernel modules have a new location (bsc#1214329)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -219,6 +219,7 @@ kernel/net/ceph/.*
 kernel/net/phonet/.*
 kernel/net/802/.*
 updates/drivers/gpu/.*
+kernel/fs/smb/.*,,-
 
 
 ; acpi

--- a/etc/module.list
+++ b/etc/module.list
@@ -92,6 +92,7 @@ kernel/fs/nfsd/
 kernel/fs/nls/
 kernel/fs/ntfs/
 kernel/fs/overlayfs/
+kernel/fs/smb/
 kernel/fs/smbfs/
 kernel/fs/squashfs/
 kernel/fs/udf/


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1214329

Cifs installation no longer working.

cifs kernel modules have been relocated and are now in subdirectories of `kernel/fs/smb`.