### PR TITLE
add mt to rescue system (bsc#1188998)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -122,6 +122,7 @@ checkmedia:
 cifs-utils:
 coreutils:
 cpio:
+cpio-mt:
 cracklib-dict-full:
 cracklib:
 cryptsetup:

--- a/etc/module.config
+++ b/etc/module.config
@@ -217,6 +217,7 @@ kernel/net/ceph/.*
 kernel/net/phonet/.*
 kernel/net/802/.*
 updates/drivers/gpu/.*
+kernel/fs/smb/.*,,-
 
 
 ; acpi

--- a/etc/module.list
+++ b/etc/module.list
@@ -94,6 +94,7 @@ kernel/fs/ntfs/
 kernel/fs/overlayfs/
 kernel/fs/reiser4/
 kernel/fs/reiserfs/
+kernel/fs/smb/
 kernel/fs/smbfs/
 kernel/fs/squashfs/
 kernel/fs/udf/

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -345,6 +345,7 @@ BuildRequires:  ca-certificates-mozilla
 BuildRequires:  cairo
 BuildRequires:  checkmedia
 BuildRequires:  cifs-utils
+BuildRequires:  cpio-mt
 BuildRequires:  cracklib
 BuildRequires:  cracklib-dict-full
 BuildRequires:  cron


### PR DESCRIPTION
## Tasks

1. Add `mt` package to rescue system
    - https://bugzilla.suse.com/show_bug.cgi?id=1188998
    - port to SLE15-SP6: https://github.com/openSUSE/installation-images/pull/640
2. `cifs` kernel modules have been relocated
    - https://bugzilla.suse.com/show_bug.cgi?id=1214329
    - port to SLE15-SP6: https://github.com/openSUSE/installation-images/pull/654