### PR TITLE
cifs kernel modules have a new location (bsc#1214329)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -217,6 +217,7 @@ kernel/net/ceph/.*
 kernel/net/phonet/.*
 kernel/net/802/.*
 updates/drivers/gpu/.*
+kernel/fs/smb/.*,,-
 
 
 ; acpi

--- a/etc/module.list
+++ b/etc/module.list
@@ -94,6 +94,7 @@ kernel/fs/ntfs/
 kernel/fs/overlayfs/
 kernel/fs/reiser4/
 kernel/fs/reiserfs/
+kernel/fs/smb/
 kernel/fs/smbfs/
 kernel/fs/squashfs/
 kernel/fs/udf/


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/654 to SLE15-SP4.

## Original problem

https://bugzilla.suse.com/show_bug.cgi?id=1214329

Cifs installation no longer working.

cifs kernel modules have been relocated and are now in subdirectories of `kernel/fs/smb`.