### PR TITLE
BuildConflict libpxbackend-1_0-mini (boo#1215290)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -495,6 +495,8 @@ BuildRequires:  util-linux-systemd
 BuildRequires:  valgrind
 BuildRequires:  vim-small
 BuildRequires:  wget
+# wget pulls in libproxy1, which in turn pulls in libpxbackend-1_0; to counter cycles, this exists as mini
+#!BuildConflicts: libpxbackend-1_0-mini
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools


### PR DESCRIPTION
wget pulls in libproxy1 which in turn pulls in libpxbackend-1_0;
to counter cycles, this exists as mini. Declare the mini to be
in conflict for installation-images.
