### PR TITLE
drop unused wget (bsc#1215290)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -201,7 +201,6 @@ usbutils:
 util-linux:
 vim-small:
 vlan:
-wget:
 ?wicked:
 ?xen-tools-domU:
 xfsdump:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -194,7 +194,6 @@ systemd:
 udftools:
 usbutils:
 util-linux:
-wget:
 xfsdump:
 xfsprogs:
 xz:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -494,7 +494,6 @@ BuildRequires:  util-linux
 BuildRequires:  util-linux-systemd
 BuildRequires:  valgrind
 BuildRequires:  vim-small
-BuildRequires:  wget
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1215290

Unwanted dependency on `libpxbackend-1_0-mini` slips in which would have to be avoided explicitly in spec file. See https://github.com/openSUSE/installation-images/pull/658.

## Solution

Drop `wget`. It's not used (AFAICS) and we have `curl` available.