### PR TITLE
Add kernel modules for Lenovo X13s (bsc#1215326)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -182,6 +182,12 @@ tegra20-apb-dma
 
 reset-rzg2l-usbphy-ctrl
 
+clk-rpmh
+dispcc-sc8280xp
+gcc-sc8280xp
+qcom_q6v5
+qcom_q6v5_pas
+
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-
 kernel/crypto/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -272,6 +272,13 @@ kernel/drivers/net/mdio/mdio-bcm-unimac.ko
 
 kernel/drivers/reset/reset-rzg2l-usbphy-ctrl.ko
 
+# Lenovo X13s (aarch64)
+kernel/drivers/clk/qcom/clk-rpmh.ko
+kernel/drivers/clk/qcom/dispcc-sc8280xp.ko
+kernel/drivers/clk/qcom/gcc-sc8280xp.ko
+kernel/drivers/remoteproc/qcom_q6v5.ko
+kernel/drivers/remoteproc/qcom_q6v5_pas.ko
+
 # kmps
 updates/
 


### PR DESCRIPTION
Booting Linux kernel on X13s requires some Qualcomm driver modules to be loaded early.