### PR TITLE
etc: update module.config to match 6.6

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -132,6 +132,7 @@ ptp_dfl_tod
 ptp_dte
 ptp_idt82p33
 ptp_kvm
+ptp_mock
 ptp_ocp
 ptp_pch
 ptp_qoriq


### PR DESCRIPTION
6.6 brought a new ptp module: `ptp_mock`. Put it along other ptp modules to the `[other]` section.