### PR TITLE
avoid using libpxbackend-1_0-mini (bsc#1215290)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -220,6 +220,10 @@ vim-small:
 # pull in yast2 installation related packages via package deps
 skelcd-control-<skelcd_ctrl_theme>:
 
+# explicit dependency needed by libproxy1 < libzypp
+# to avoid picking libpxbackend-1_0-mini (see bsc#1215290)
+libpxbackend-*:
+
 rpm:
   /etc
   /usr/bin

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -494,6 +494,8 @@ BuildRequires:  util-linux
 BuildRequires:  util-linux-systemd
 BuildRequires:  valgrind
 BuildRequires:  vim-small
+# libproxy1 requires libpxbackend-1_0; to counter cycles, this exists also as mini (bsc#215290)
+#!BuildConflicts: libpxbackend-1_0-mini
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1215290

Unwanted choice between ``libpxbackend-1_0` and `libpxbackend-1_0-mini` slips in which has to be avoided explicitly.

## Solution

This has to be adjusted in two places:

1. adjust `root.file_list` for local builds outside OBS
2. adjust spec file to avoid  `libpxbackend-1_0-mini`  in OBS

## See also

- https://github.com/openSUSE/installation-images/pull/658
- https://github.com/openSUSE/installation-images/pull/659