### PR TITLE
Add more boot-required modules for Lenovo X13s

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -186,8 +186,16 @@ reset-rzg2l-usbphy-ctrl
 clk-rpmh
 dispcc-sc8280xp
 gcc-sc8280xp
+gpucc-sc8280xp
+nvmem_qcom-spmi-sdam
+qcom_hwspinlock
 qcom_q6v5
 qcom_q6v5_pas
+qnoc-sc8280xp
+pmic_glink
+pmic_glink_altmode
+smp2p
+spmi-pmic-arb
 
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-

--- a/etc/module.list
+++ b/etc/module.list
@@ -276,8 +276,17 @@ kernel/drivers/reset/reset-rzg2l-usbphy-ctrl.ko
 kernel/drivers/clk/qcom/clk-rpmh.ko
 kernel/drivers/clk/qcom/dispcc-sc8280xp.ko
 kernel/drivers/clk/qcom/gcc-sc8280xp.ko
+kernel/drivers/clk/qcom/gpucc-sc8280xp.ko
+kernel/drivers/hwspinlock/qcom_hwspinlock.ko
+kernel/drivers/interconnect/qcom/qnoc-sc8280xp.ko
+kernel/drivers/leds/rgb/leds-qcom-lpg.ko
+kernel/drivers/nvmem/nvmem_qcom-spmi-sdam.ko
 kernel/drivers/remoteproc/qcom_q6v5.ko
 kernel/drivers/remoteproc/qcom_q6v5_pas.ko
+kernel/drivers/soc/qcom/pmic_glink.ko
+kernel/drivers/soc/qcom/pmic_glink_altmode.ko
+kernel/drivers/soc/qcom/smp2p.ko
+kernel/drivers/spmi/spmi-pmic-arb.ko
 
 # kmps
 updates/


### PR DESCRIPTION
Add Qualcomm's GPU clk, LCD backlight, and power-related [spmi & pmic] modules required for booting installer on Lenovo X13s. (bsc#1215326)