### PR TITLE
add kernel modules needed for MediaTek boards 'mt8195-demo' and 'genio-1200-evk' (bsc#1215995)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -197,11 +197,25 @@ pmic_glink_altmode
 smp2p
 spmi-pmic-arb
 
+reset-raspberrypi
+clk-raspberrypi
+raspberrypi-cpufreq
+cpufreq-dt
+sdhci
+sdhci-iproc
+gpio-raspberrypi-exp
+mdio-bcm-unimac
+
+mt6360_charger
+mtk-pmic-wrap
+nvmem_mtk-efuse
+
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-
 kernel/crypto/.*
 kernel/drivers/base/regmap/.*
 kernel/drivers/.*/crypto/.*
+kernel/drivers/clk/.*
 kernel/drivers/crypto/.*
 kernel/drivers/firmware/.*
 kernel/drivers/gpio/.*
@@ -649,14 +663,6 @@ af_iucv
 kernel/drivers/s390/.*
 kernel/arch/s390/.*
 
-reset-raspberrypi
-clk-raspberrypi
-raspberrypi-cpufreq
-cpufreq-dt
-sdhci
-sdhci-iproc
-gpio-raspberrypi-exp
-mdio-bcm-unimac
 
 ; modules we do _not_ need
 [notuseful]

--- a/etc/module.list
+++ b/etc/module.list
@@ -288,6 +288,11 @@ kernel/drivers/soc/qcom/pmic_glink_altmode.ko
 kernel/drivers/soc/qcom/smp2p.ko
 kernel/drivers/spmi/spmi-pmic-arb.ko
 
+kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
+kernel/drivers/power/supply/mt6360_charger.ko
+kernel/drivers/nvmem/nvmem_mtk-efuse.ko
+kernel/drivers/clk/
+
 # kmps
 updates/
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1215995

Add kernel modules proposed in https://bugzilla.suse.com/show_bug.cgi?id=1215995#c21. With one change: I've added all
modules from `kernel/drivers/clk`.