### PR TITLE
remove termcap dependency, it's not used (bsc#1216448)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -485,7 +485,6 @@ BuildRequires:  squashfs
 BuildRequires:  star
 BuildRequires:  strace
 BuildRequires:  tcpd-devel
-BuildRequires:  termcap
 BuildRequires:  terminfo
 BuildRequires:  udftools
 BuildRequires:  un-fonts


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1216448

`termcap` is not needed; remove in BuildRequires.
