### PR TITLE
Add DTB installation support for Lenovo X13s (bsc#1215647)

### DIFF
--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -91,8 +91,14 @@ if arch eq 'aarch64' || arch eq 'armv7l' || arch eq 'armv6l'
     else
       u-boot-rpi3:
         /
+    endif
+    e mv boot/vc/* .
+    r /boot /usr
   endif
-  e mv boot/vc/* .
-  r /boot /usr
+  if exists(lenovo-x13s-firmware-dt)
+    lenovo-x13s-firmware-dt:
+      /
+    e cp usr/share/arm64laptop-firmware-dt/lenovo-x13s/* .
+    r /usr
   endif
 endif

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -636,6 +636,7 @@ BuildRequires:  raspberrypi-firmware-config
 BuildRequires:  raspberrypi-firmware-dt
 BuildRequires:  arm-trusted-firmware-rpi4
 BuildRequires:  u-boot-rpiarm64
+BuildRequires:  lenovo-x13s-firmware-dt
 %if %with_shim
 BuildRequires:  shim
 %endif


### PR DESCRIPTION
The X13s DTB needs to be installed on the installer's ESP otherwise the installer won't boot on Lenovo X13s since its UEFI FW does not support ACPI for Linux, and it needs to load the upstream device-tree before running into grub2 and linux kernel.