### PR TITLE
add spmi-mtk-pmif kernel module (bsc#1216767)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -196,6 +196,7 @@ pmic_glink
 pmic_glink_altmode
 smp2p
 spmi-pmic-arb
+spmi-mtk-pmif
 
 reset-raspberrypi
 clk-raspberrypi

--- a/etc/module.list
+++ b/etc/module.list
@@ -287,6 +287,7 @@ kernel/drivers/soc/qcom/pmic_glink.ko
 kernel/drivers/soc/qcom/pmic_glink_altmode.ko
 kernel/drivers/soc/qcom/smp2p.ko
 kernel/drivers/spmi/spmi-pmic-arb.ko
+kernel/drivers/spmi/spmi-mtk-pmif.ko
 
 kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
 kernel/drivers/power/supply/mt6360_charger.ko


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1216767

Add `spmi-mtk-pmif` kernel module. Relevant for aarch64.