### PR TITLE
add TPM support (bsc#1216835)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -102,6 +102,8 @@ sysconfig-netconfig:
 sg3_utils:
 systemd-presets-branding-<systemd_theme>:
 tar:
+tpm2.0-tools:
+tpm2.0-abrmd:
 util-linux-systemd:
 vlan:
 which:
@@ -686,6 +688,7 @@ r /etc/profile.d
 if arch ne 's390' && arch ne 's390x'
   r /boot
 endif
+r /usr/share/applications/gnome-mimeapps.list
 
 # mtab is symlink now
 r /etc/mtab

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -113,3 +113,8 @@ if [ ! -f /etc/firmware_devices ] ; then
   done < <(/etc/wicked/extensions/ibft -l)
   echo "ibftdevices: $ibft" >/etc/ibft_devices
 fi
+
+# tpm support
+if [ -c /dev/tpm0 -a -x /usr/sbin/tpm2-abrmd ] ; then
+  /usr/sbin/tpm2-abrmd --allow-root > /var/log/tpm.log 2>&1 &
+fi

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -514,6 +514,8 @@ BuildRequires:  systemd-sysvinit
 BuildRequires:  tcpd-devel
 BuildRequires:  termcap
 BuildRequires:  terminfo
+BuildRequires:  tpm2.0-abrmd
+BuildRequires:  tpm2.0-tools
 BuildRequires:  udftools
 BuildRequires:  un-fonts
 BuildRequires:  usbutils


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/670 to SLE15-SP5.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1216835

Add TPM support to installation system.

This only makes the TPM accessible. TheTPM  is not used in any way by default.

In detail:

- `tpm2.0-tools` are added
- auto-start `tpm2-abrmd` (the TPM communication daemon) if `/dev/tpm0` exists

With this, you can read the PCR values with `tpm2 pcrread`, for example.