### PR TITLE
fix dangling symlink detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,8 +122,8 @@ initrd+modules+gefrickel: base
 	rm -rf tmp/initrd/modules tmp/initrd/lib/modules tmp/initrd_gefrickel
 	# work on a copy to not modify the origial tree
 	cp -a tmp/initrd tmp/initrd_gefrickel
-	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=modules src=initrd fs=none bin/mk_image
-	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=digests src=initrd fs=none bin/mk_image
+	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=modules src=initrd fs=none nolinkcheck=1 bin/mk_image
+	theme=$(THEMES) mode=add tmpdir=initrd_gefrickel image=digests src=initrd fs=none nolinkcheck=1 bin/mk_image
 	mkdir -p images/module-config/$${MOD_CFG:-default}
 	ls -I module.config tmp/initrd_gefrickel/modules | sed -e 's#.*/##' >images/module-config/$${MOD_CFG:-default}/module.list
 	cp tmp/initrd_gefrickel/modules/module.config images/module-config/$${MOD_CFG:-default}
@@ -162,7 +162,7 @@ tftp: base
 	for i in `cat images/rpmlist` ; do \
 	  echo -e "$$i:\n  X <rpm_file> <tftp_dir>/<instsys_dir>\n" >> data/boot/gen/rpm.file_list; \
 	done
-	theme=$(THEMES) image=tftp src=boot fs=dir bin/mk_image
+	theme=$(THEMES) image=tftp src=boot fs=dir nolinkcheck=1 bin/mk_image
 	rm -f images/tftp/{.packages.tftp,content}
 
 root: base

--- a/bin/mk_image
+++ b/bin/mk_image
@@ -188,6 +188,8 @@ sub check_link
     next if $dangling_links->{$ds} eq $x;
 
     if($x =~ /^\//) {
+      # absolute links
+
       next if $x =~ m#^/lbin/#;
       next if $x =~ m#^/proc/#;
       next if $x =~ m#^/dev/#;
@@ -196,8 +198,12 @@ sub check_link
       next if -l "$dir$x" || -e _;
     }
     else {
+      # relative links
+
+      my $s = $ds;
+      $s =~ s#[^/]+$#$x#;
       # don't verify symlinks to symlinks
-      next if -l || -e _;
+      next if -l "$dir/$s" || -e _;
     }
     $err = 1;
     my $n = $_;

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -697,3 +697,10 @@ e ldconfig -r .
 # get the gpg keys to trust from build root
 d /usr/lib/rpm/gnupg/keys
 X /usr/lib/rpm/gnupg/keys /usr/lib/rpm/gnupg
+
+# allowed dangling symlinks
+D ../share/cracklib/pw_dict.pwi /usr/lib/cracklib_dict.pwi
+D ../share/cracklib/pw_dict.pwd /usr/lib/cracklib_dict.pwd
+D ../share/cracklib/pw_dict.hwm /usr/lib/cracklib_dict.hwm
+D ../../../var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
+D brcmfmac43455-sdio.raspberrypi,4-model-b.txt.xz /usr/lib/firmware/brcm/brcmfmac43455-sdio.raspberrypi,4-compute-module.txt.xz

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -114,7 +114,7 @@ if [ ! -f /etc/firmware_devices ] ; then
   echo "ibftdevices: $ibft" >/etc/ibft_devices
 fi
 
-# tpm suppurt
+# tpm support
 if [ -c /dev/tpm0 -a -x /usr/sbin/tpm2-abrmd ] ; then
   /usr/sbin/tpm2-abrmd --allow-root > /var/log/tpm.log 2>&1 &
 fi

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -458,7 +458,6 @@ E echo "devpts /dev/pts devpts mode=0620,gid=5 0 0" >>/etc/fstab
 d usr/lib/microcode
 
 # allowed dangling symlinks
-D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list
+D ../../../etc/sysctl.conf /usr/lib/sysctl.d/99-sysctl.conf
+D ../../../var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D /etc/machine-id /var/lib/dbus/machine-id

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -690,7 +690,7 @@ r /etc/passwd* /etc/shadow* /etc/group*
 r etc/mtab
 
 # remove these, we don't want them symlinked
-r root mnt tmp proc usr/libexec
+r root mnt tmp proc
 
 x /usr/lib/YaST/.Reh /usr/lib/YaST2
 x etc/inst_setup /sbin/inst_setup
@@ -742,11 +742,11 @@ E /check_fonts usr/share/YaST2/theme
 e rm check_fonts fc-match
 
 # allowed dangling symlinks
-D ../../sbin/update-ca-certificates /usr/lib64/p11-kit/p11-kit-extract-trust
-D ../../sbin/update-ca-certificates /usr/lib/p11-kit/p11-kit-extract-trust
-D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list
+D ../systemd-firstboot.service /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service
+D system-generators/systemd-fstab-generator /usr/lib/systemd/systemd-sysroot-fstab-check
+D ../../../etc/sysctl.conf /usr/lib/sysctl.d/99-sysctl.conf
+D ../../sbin/update-ca-certificates /usr/libexec/p11-kit/p11-kit-extract-trust
+D ../../../var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
 D ../share/cracklib/pw_dict.pwi /usr/lib/cracklib_dict.pwi
 D ../share/cracklib/pw_dict.pwd /usr/lib/cracklib_dict.pwd
 D ../share/cracklib/pw_dict.hwm /usr/lib/cracklib_dict.hwm

--- a/data/root/zenroot.file_list
+++ b/data/root/zenroot.file_list
@@ -152,9 +152,6 @@ procinfo:
 
 x /etc/ld.so.conf /etc
 
-# remove these:
-r root mnt tmp usr/libexec
-
 :
   r /usr/lib*/security/pam_userdb.so
 
@@ -242,7 +239,7 @@ r /etc/passwd* /etc/shadow* /etc/group*
 r etc/mtab
 
 # remove these, we don't want them symlinked
-r root mnt tmp proc usr/libexec
+r root mnt tmp proc
 
 x etc/inst_setup /sbin/inst_setup
 x hostip_from_wicked /sbin/hostip_from_wicked
@@ -263,6 +260,7 @@ r /etc/resolv.conf
 E TZ= LANG= LC_ALL= date +%Y%m%d >.timestamp
 
 # allowed dangling symlinks
-D /var/cache/gio-2.0/gnome-defaults.list /usr/share/applications/defaults.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
-D /var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/mimeapps.list
+D ../../../var/cache/gio-2.0/gnome-mimeapps.list /usr/share/applications/gnome-mimeapps.list
+D ../systemd-firstboot.service /usr/lib/systemd/system/sysinit.target.wants/systemd-firstboot.service
+D system-generators/systemd-fstab-generator /usr/lib/systemd/systemd-sysroot-fstab-check
+D ../../../etc/sysctl.conf /usr/lib/sysctl.d/99-sysctl.conf

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -445,6 +445,8 @@ BuildRequires:  systemd-presets-branding
 BuildRequires:  sysvinit-tools
 BuildRequires:  tftpboot-installation-common
 BuildRequires:  thai-fonts
+BuildRequires:  tpm2.0-abrmd
+BuildRequires:  tpm2.0-tools
 BuildRequires:  tunctl
 BuildRequires:  udev
 BuildRequires:  vlan


### PR DESCRIPTION
## Problem

Detecting dangling symlinks was broken for relative symlinks.

Fix it and adjust config accordingly.

## Bonus

Add required TPM packages to spec file.