### PR TITLE
Updates for riscv64

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -70,7 +70,8 @@ TEMPLATE ruby\d+\.\d+:
   r /usr/bin/rake*
   r /usr/bin/{y2,}racc*
   r /usr/bin/rdoc*
-  r /usr/bin/ri*
+  r /usr/bin/ri
+  r /usr/bin/ri.*
   r /usr/bin/bundle*
   r /usr/bin/rbs*
   r /usr/bin/typeprof*

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -459,9 +459,7 @@ BuildRequires:  plymouth-scripts
 BuildRequires:  plymouth-theme-tribar
 %endif
 BuildRequires:  klogd
-%ifnarch riscv64
 BuildRequires:  ltrace
-%endif
 BuildRequires:  nscd
 BuildRequires:  polkit
 BuildRequires:  popt-devel


### PR DESCRIPTION
- ltrace now exists for riscv64
- Fix too broad glob in ruby template
