### PR TITLE
Add dbus-1-daemon

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -59,6 +59,7 @@ AUTODEPS:
 
 binutils: ignore
 dbus-1-x11: ignore
+dbus-broker: ignore
 dirmngr: ignore
 fillup: ignore
 gnu-unifont-bitmap-fonts: ignore
@@ -468,6 +469,9 @@ dbus-1:
 dbus-1-common:
   /
   E prein
+
+dbus-1-daemon:
+  /usr/bin/dbus-daemon
 
 # For FIPS installation:
 

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -323,6 +323,7 @@ BuildRequires:  cryptsetup
 BuildRequires:  cups-libs
 BuildRequires:  curl
 BuildRequires:  dash
+BuildRequires:  dbus-1-daemon
 BuildRequires:  dbus-1-x11
 BuildRequires:  dd_rescue
 BuildRequires:  debuginfod-client


### PR DESCRIPTION
dbus-1 is being switched to dbus-broker but initrd doesn't have systemd so it can't be used so keep dbus-daemon