### PR TITLE
etc: update module.config to match 6.7

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -686,6 +686,7 @@ ipwireless
 iscsi_trgt
 mctp-serial
 mctp-i2c
+mctp-i3c
 msdos
 netdevsim
 parport_ax88796


### PR DESCRIPTION
6.7 brought a new mctp module: mctp-i3c. Put it along mctp-i2c.