### PR TITLE
include complete system-role-common-criteria package (bsc#1217968, bsc#1218652)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -310,8 +310,7 @@ strace:
   /usr/share/YaST2/lib/y2system_role_handlers/sap_business_one_role_finish.rb
 
 ?system-role-common-criteria: nodeps
-  /usr/share/YaST2/lib/y2system_role_handlers/cc_role_finish.rb
-  /usr/share/YaST2/clients/inst_cc_mode.rb
+  /
 
 yast2:
   /etc


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1218652

Port https://github.com/openSUSE/installation-images/pull/676 to SLE15-SP5.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1217968

Include complete `system-role-common-criteria` package. Previously, only selected files were added - and the file list got outdated.