### PR TITLE
s390-tools now available for non-s390x archs (jsc#PED-7136, jsc#PED-7138)

### DIFF
--- a/data/base/base.file_list
+++ b/data/base/base.file_list
@@ -110,7 +110,9 @@ procinfo:
 procps:
 psmisc:
 rpm:
-?s390-tools:
+if arch eq 's390x'
+  s390-tools:
+endif
 sed:
 shadow:
 squashfs:

--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -102,7 +102,9 @@ patch:
 sed:
 ?wicked:
 ?wicked-nbft:
-?s390-tools-hmcdrvfs:
+if arch eq 's390x'
+  s390-tools-hmcdrvfs:
+endif
 rsyslog:
 sysconfig-netconfig:
 sg3_utils:
@@ -176,7 +178,9 @@ terminfo:
 suse-module-tools:
   /etc/modprobe.d
 
-?s390-tools:
+if arch eq 's390x'
+  s390-tools:
+endif
 
 kbd:
   /usr/bin/dumpkeys
@@ -680,8 +684,8 @@ x etc/rsyslog.conf etc
 
 # additional scripts for linuxrc
 x scripts /
-# hmc exists only on s390
-if !exists(s390-tools-hmcdrvfs)
+# hmc exists only on s390x
+if arch ne 's390x'
   r /scripts/url/hmc
 endif
 

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -110,7 +110,9 @@ binutils: ignore
 ?pdisk:
 ?powerpc-utils:
 ?powertop:
-?s390-tools:
+if arch eq 's390x'
+  s390-tools:
+endif
 ?silo:
 ?wireless-tools:
 ?wpa_supplicant:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -592,9 +592,11 @@ aaa_base:
   E postin
   r /run/utmp
 
-?s390-tools:
-  /
-  E postin
+if arch eq 's390x'
+  s390-tools:
+    /
+    E postin
+endif
 
 rpcbind:
   /


### PR DESCRIPTION
## Task

- https://jira.suse.com/browse/PED-7136
- https://jira.suse.com/browse/PED-7138

`s390-tools` package is now available on all architectures. Adjust config to include s390-tools only on s390x. Previously is was implicitly assumed the package exists only on s390x.