### PR TITLE
noto-naskharabic-fonts is now google-noto-naskharabic-fonts

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -564,7 +564,7 @@ khmeros-fonts:
 
 lklug-fonts:
 
-noto-naskharabic-fonts:
+google-noto-naskharabic-fonts:
 
 dmz-icon-theme-cursors:
   if exists(dmz-icon-theme-cursors, /usr/share/icons/DMZ-White)

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -337,7 +337,7 @@ BuildRequires:  ed
 BuildRequires:  efont-unicode-bitmap-fonts
 BuildRequires:  elfutils
 BuildRequires:  ethtool
-BuildRequires:  noto-naskharabic-fonts
+BuildRequires:  google-noto-naskharabic-fonts
 %if %with_exfat
 BuildRequires:  exfatprogs
 %endif


### PR DESCRIPTION
## Task

`noto-naskharabic-fonts` has been renamed to `google-noto-naskharabic-fonts`.

## See also

This is based on https://github.com/openSUSE/installation-images/pull/680.
