### PR TITLE
drop finger (bsc#1218794)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -142,7 +142,6 @@ e2fsprogs:
 file-magic:
 file:
 findutils:
-finger:
 gpart:
 ?gptfdisk:
 grep:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -342,7 +342,6 @@ BuildRequires:  google-noto-naskharabic-fonts
 BuildRequires:  exfatprogs
 %endif
 BuildRequires:  fbiterm
-BuildRequires:  finger
 BuildRequires:  fonts-config
 BuildRequires:  gamin-server
 BuildRequires:  gdb


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1218794

Drop obsolete `finger` tool from rescue system.