### PR TITLE
Remove more binaries appearing with Ruby 3.3

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -76,6 +76,7 @@ TEMPLATE ruby\d+\.\d+:
   r /usr/bin/rbs*
   r /usr/bin/typeprof*
   r /usr/bin/rdbg*
+  r /usr/bin/syntax_suggest*
 
 TEMPLATE:
   /


### PR DESCRIPTION
Ruby 3.3 ships a new `syntax_suggest` binary, which we do not need
in the installation-images.

I hope this would fix the issues currently seen in Staging:I (ruby 3.3)

```
[  318s] checking for dangling symlinks...
[  318s] invalid: /usr/bin/syntax_suggest -> /etc/alternatives/syntax_suggest
[  318s] invalid: /usr/bin/syntax_suggest.ruby3.3 -> /etc/alternatives/syntax_suggest.ruby3.3
[  318s] mk_image: please fix symlinks
[  318s] make: *** [Makefile:169: root] Error 9
```