### PR TITLE
use kernel-firmware-all instead of kernel-firmware (bsc#1214789)

### DIFF
--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -26,7 +26,7 @@ close F;
 for $m (sort keys %fw) {
   for $fw (@{$fw{$m}}) {
     my $ok = 0;
-    for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw>) {
+    for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw $fw_dir/$fw.xz $fw_dir/$kv/$fw.xz $fw_dir/$fw.zst $fw_dir/$kv/$fw.zst>) {
       if(-r $f) {
         $f =~ s#^$fw_dir/##;
         system "install -m 644 -D '$fw_dir/$f' 'lib/firmware/$f'\n";

--- a/etc/config
+++ b/etc/config
@@ -45,9 +45,9 @@ x86_64	= virtualbox-guest,xen,drm
 
 ; extra firmware packages
 [Firmware]
-default = kernel-firmware,adaptec-firmware
-i386    = kernel-firmware,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
-x86_64  = kernel-firmware,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
+default = kernel-firmware-all,adaptec-firmware
+i386    = kernel-firmware-all,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
+x86_64  = kernel-firmware-all,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
 
 
 ; lib directory

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -376,7 +376,7 @@ BuildRequires:  kernel-default
 BuildRequires:  kernel-default-extra
 BuildRequires:  kernel-default-optional
 %endif
-BuildRequires:  kernel-firmware
+BuildRequires:  kernel-firmware-all
 BuildRequires:  kexec-tools
 BuildRequires:  khmeros-fonts
 BuildRequires:  kmod-compat


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1214789

Drop dependency on `kernel-firmware` package.

Instead use kernel firmware packages that `kernel-firmware-all` requires.