### PR TITLE
use kernel-firmware-all instead of kernel-firmware (bsc#1214789)

### DIFF
--- a/data/base/mlist3
+++ b/data/base/mlist3
@@ -26,7 +26,7 @@ close F;
 for $m (sort keys %fw) {
   for $fw (@{$fw{$m}}) {
     my $ok = 0;
-    for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw>) {
+    for my $f (<$fw_dir/$fw $fw_dir/$kv/$fw $fw_dir/$fw.xz $fw_dir/$kv/$fw.xz $fw_dir/$fw.zst $fw_dir/$kv/$fw.zst>) {
       if(-r $f) {
         $f =~ s#^$fw_dir/##;
         system "install -m 644 -D '$fw_dir/$f' 'lib/firmware/$f'\n";

--- a/etc/config
+++ b/etc/config
@@ -44,9 +44,9 @@ x86_64	= virtualbox-guest,xen,drm,reiserfs
 
 ; extra firmware packages
 [Firmware]
-default = kernel-firmware,adaptec-firmware
-i386    = kernel-firmware,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
-x86_64  = kernel-firmware,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
+default = kernel-firmware-all,adaptec-firmware
+i386    = kernel-firmware-all,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
+x86_64  = kernel-firmware-all,adaptec-firmware,ipw-firmware,iwl4965-ucode,iwl5000-ucode,atmel-firmware,ralink-firmware
 
 
 ; lib directory

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -166,7 +166,7 @@ require Exporter;
 @EXPORT = qw (
   $Script $BasePath $LibPath $BinPath $CfgPath $ImagePath $DataPath
   $TmpBase %ConfigData ReadFile RealRPM RealRPMs ReadRPM $SUBinary SUSystem Print2File $MToolsCfg $AutoBuild
-  ResolveDeps
+  ResolveDeps CopyRPM
 );
 
 use strict 'vars';
@@ -388,6 +388,23 @@ sub UnpackRPM
 
 
 #
+# Unpack rpm_name to target_dir and return path to cache dir or undef if failed.
+#
+sub CopyRPM
+{
+  my $rpm_name = $_[0];
+  my $target_dir = $_[1];
+
+  my $cache_dir = ReadRPM($rpm_name);
+  if($cache_dir) {
+    system "tar -C '$cache_dir/rpm' -cf - . | tar -C '$target_dir' -xf -";
+  }
+
+  return $cache_dir;
+}
+
+
+#
 # Unpack rpm to cache dir and return path to dir or undef if failed.
 #
 sub ReadRPM
@@ -464,20 +481,35 @@ sub ReadRPM
       undef $kv;
     }
 
-    UnpackRPM RealRPM("$rpm->{name}-base"), $tdir;
-    UnpackRPM RealRPM("$rpm->{name}-extra"), $tdir;
-    UnpackRPM RealRPM("$rpm->{name}-optional"), $tdir;
+    CopyRPM "$rpm->{name}-base", $tdir;
+    CopyRPM "$rpm->{name}-extra", $tdir;
+    CopyRPM "$rpm->{name}-optional", $tdir;
 
     my $kmp;
     for (split(',', $ConfigData{kmp_list})) {
       ($kmp = $rpm->{name}) =~ s/^kernel/$_-kmp/;
       print "adding kmp $kmp\n";
-      UnpackRPM RealRPM($kmp), $tdir;
+      CopyRPM $kmp, $tdir;
     }
 
     for (split(',', $ConfigData{fw_list})) {
-      print "adding firmware $_\n";
-      UnpackRPM RealRPM($_), $tdir;
+      if($_ eq 'kernel-firmware-all') {
+        my $rpm = ReadRPM($_);
+        if($rpm) {
+          my $deps = ReadFile "$rpm/requires";
+          for my $fw (split /\n/, $deps) {
+            if($fw =~ /^(kernel-firmware-\S+)/) {
+              $fw = $1;
+              print "adding firmware $fw\n";
+              CopyRPM $fw, $tdir;
+            }
+          }
+        }
+      }
+      else {
+        print "adding firmware $_\n";
+        CopyRPM $_, $tdir;
+      }
     }
 
     # keep it readable

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -405,7 +405,7 @@ BuildRequires:  kernel-default
 BuildRequires:  kernel-default-extra
 BuildRequires:  kernel-default-optional
 %endif
-BuildRequires:  kernel-firmware
+BuildRequires:  kernel-firmware-all
 BuildRequires:  kexec-tools
 BuildRequires:  khmeros-fonts
 BuildRequires:  kmod-compat


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/687 to SLE15-SP6.

## Original Task

- https://bugzilla.suse.com/show_bug.cgi?id=1214789

Drop dependency on `kernel-firmware` package.

Instead use kernel firmware packages that `kernel-firmware-all` requires.