### PR TITLE
change HMC console name from ttyS1 to ttysclp0 (bsc#1203405)

### DIFF
--- a/data/initrd/s390/parmfile.hmc
+++ b/data/initrd/s390/parmfile.hmc
@@ -1,2 +1,2 @@
-TERM=xterm manual=1 console=ttyS1
+TERM=xterm manual=1 console=ttysclp0
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1203405

Default HMC console device name changed from `ttyS1` to `ttysclp0`.

## See also

- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b7d91d230a119fdcc334d10c9889ce9c5e15118b