### PR TITLE
no libcryptsetup12-hmac, libgcrypt20-hmac anymore (bsc#1219762)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -285,8 +285,6 @@ gpg2:
   d root/.gnupg
 
 cryptsetup:
-?libcryptsetup*-hmac:
-?libgcrypt20-hmac:
 
 ntfs-3g:
   /

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -144,7 +144,6 @@ cpio:
 # Do not remove cryptsetup even though it's also listed in initrd.file_list
 # because of the dropped dependency to cracklib-dict-xxx in the initrd.
 cryptsetup:
-?libcryptsetup*-hmac:
 device-mapper:
 dosfstools:
 e2fsprogs:


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1219762

There are no separate `libcryptsetup12-hmac` and `libgcrypt20-hmac` packages anymore.