### PR TITLE
no libcryptsetup12-hmac, libgcrypt20-hmac anymore (bsc#1219762)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -300,8 +300,6 @@ gpg2:
   d root/.gnupg
 
 cryptsetup:
-?libcryptsetup*-hmac:
-?libgcrypt20-hmac:
 
 # XXX: usrmerge
 ntfs-3g:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -148,7 +148,6 @@ cpio:
 # Do not remove cryptsetup even though it's also listed in initrd.file_list
 # because of the dropped dependency to cracklib-dict-xxx in the initrd.
 cryptsetup:
-?libcryptsetup*-hmac:
 device-mapper:
 dosfstools:
 e2fsprogs:


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/697 to SLE15-SP6.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1219762

There are no separate `libcryptsetup12-hmac` and `libgcrypt20-hmac` packages anymore.