### PR TITLE
remove haveged (bsc#1219910)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -85,7 +85,6 @@ curl:
 device-mapper:
 ethtool:
 glibc:
-haveged:
 hostname:
 hwinfo:
 iputils:

--- a/data/initrd/scripts/early_setup
+++ b/data/initrd/scripts/early_setup
@@ -4,18 +4,6 @@ exec >&2
 
 chmod 700 /root/.gnupg
 
-if [ -x /usr/sbin/haveged ] ; then
-  /usr/sbin/haveged -w 1024 -v 0
-
-  # Adjust the OOM killer score so kernel prefers killing the haveged
-  # daemon instead of the YaST installer (or it's child).
-  # The entropy will be collected by kernel anyway, just slower without haveged.
-  if [ -f /var/run/haveged.pid ] ; then
-    haveged_pid=`cat /var/run/haveged.pid`
-    echo 1000 > /proc/$haveged_pid/oom_score_adj
-  fi
-fi
-
 if [ -d /usr/lib/rpm/gnupg/keys ] ; then
   touch /installkey.gpg
   gpg --batch --homedir /root/.gnupg --no-default-keyring --ignore-time-conflict --ignore-valid-from --keyring /installkey.gpg --import /usr/lib/rpm/gnupg/keys/*

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -354,7 +354,6 @@ BuildRequires:  gpm
 BuildRequires:  gptfdisk
 BuildRequires:  graphviz
 BuildRequires:  graphviz-gnome
-BuildRequires:  haveged
 BuildRequires:  hdparm
 BuildRequires:  hex
 BuildRequires:  hfsutils


### PR DESCRIPTION
Starting from Linux kernel v5.4, the HAVEGED inspired algorithm has been included in the Linux kernel. Additionally, since v5.6, as soon as the CRNG gets ready, /dev/random does not block on reads anymore.