### PR TITLE
no more libstoragemgmt-netapp-plugin (bsc#1221699, jsc#PED-7948)

### DIFF
--- a/data/root/libstoragemgmt.file_list
+++ b/data/root/libstoragemgmt.file_list
@@ -2,7 +2,6 @@ TEMPLATE:
   /
 
 libstoragemgmt:
-libstoragemgmt-netapp-plugin:
 libstoragemgmt-smis-plugin:
 
 AUTODEPS:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -660,7 +660,6 @@ BuildRequires:  shim
 BuildRequires:  grub2-arm-efi
 %endif
 # inst-sys module for libstoragemgmt
-BuildRequires:  libstoragemgmt-netapp-plugin
 BuildRequires:  libstoragemgmt-smis-plugin
 # our images are not reproducible and it's taking time
 #!BuildIgnore:  build-compare


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221699
- https://jira.suse.com/browse/PED-7948

libstoragemgmt-netapp-plugin is gone, remove it.

## See also

Same for Tumbleweed:

- https://github.com/openSUSE/installation-images/pull/504