### PR TITLE
add spi drivers and pl330 (bsc#1221603)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -180,6 +180,7 @@ net_failover
 virtio_scsi
 
 tegra20-apb-dma
+pl330
 
 reset-rzg2l-usbphy-ctrl
 
@@ -237,6 +238,7 @@ kernel/drivers/phy/.*
 kernel/drivers/pinctrl/.*
 kernel/drivers/platform/.*
 kernel/drivers/regulator/.*
+kernel/drivers/spi/.*
 kernel/drivers/staging/hv/.*
 kernel/drivers/usb/common/usb-conn-gpio.ko
 kernel/drivers/usb/core/ledtrig-usbport.ko

--- a/etc/module.list
+++ b/etc/module.list
@@ -294,6 +294,9 @@ kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko
 kernel/drivers/clk/
 
+kernel/drivers/spi/
+kernel/drivers/dma/pl330.ko
+
 # kmps
 updates/
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221603

Add spi drivers and pl330.

Useful for aarch64.