### PR TITLE
add spi drivers and pl330 (bsc#1221603)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -180,6 +180,7 @@ net_failover
 virtio_scsi
 
 tegra20-apb-dma
+pl330
 
 reset-rzg2l-usbphy-ctrl
 
@@ -222,6 +223,7 @@ kernel/drivers/phy/.*
 kernel/drivers/pinctrl/.*
 kernel/drivers/platform/.*
 kernel/drivers/regulator/.*
+kernel/drivers/spi/.*
 kernel/drivers/staging/hv/.*
 kernel/drivers/usb/common/usb-conn-gpio.ko
 kernel/drivers/usb/core/ledtrig-usbport.ko

--- a/etc/module.list
+++ b/etc/module.list
@@ -290,6 +290,9 @@ kernel/drivers/soc/qcom/pmic_glink_altmode.ko
 kernel/drivers/soc/qcom/smp2p.ko
 kernel/drivers/spmi/spmi-pmic-arb.ko
 
+kernel/drivers/spi/
+kernel/drivers/dma/pl330.ko
+
 # kmps
 updates/
 


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/700 to SLE15-Sp6.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1221603

Add spi drivers and pl330.

Useful for aarch64.