### PR TITLE
Require Mesa-dri

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -292,7 +292,7 @@ BuildRequires:  noto-sans-fonts
 %ifarch ia64 %ix86 x86_64
 BuildRequires:  libsmbios_c2
 %endif
-BuildRequires:  Mesa
+BuildRequires:  Mesa-dri
 BuildRequires:  Mesa-libEGL1
 BuildRequires:  Mesa-libGL1
 BuildRequires:  aaa_base


### PR DESCRIPTION
`Mesa-dri` is important for the Qt UI
and so far was pulled in via a runtime Requires in `Mesa` but we want to drop that for cleaner build dependencies for more parallel builds.