### PR TITLE
avoid using libpxbackend-1_0-mini (bsc#1215290, bsc#1222611)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -202,7 +202,6 @@ tar:
 terminfo-base:
 usbutils:
 vlan:
-wget:
 ?wicked:
 ?xen-tools-domU:
 xfsdump:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -236,6 +236,10 @@ vim-small:
 # pull in yast2 installation related packages via package deps
 skelcd-control-<skelcd_ctrl_theme>:
 
+# explicit dependency needed by libproxy1 < libzypp
+# to avoid picking libpxbackend-1_0-mini (see bsc#1215290)
+libpxbackend-*:
+
 # XXX: usrmerge
 rpm:
   /bin

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -203,7 +203,6 @@ systemd:
 udftools:
 usbutils:
 util-linux:
-wget:
 xfsdump:
 xfsprogs:
 xz:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -514,7 +514,6 @@ BuildRequires:  util-linux
 BuildRequires:  util-linux-systemd
 BuildRequires:  valgrind
 BuildRequires:  vim-small
-BuildRequires:  wget
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -514,6 +514,8 @@ BuildRequires:  util-linux
 BuildRequires:  util-linux-systemd
 BuildRequires:  valgrind
 BuildRequires:  vim-small
+# libproxy1 requires libpxbackend-1_0; to counter cycles, this exists also as mini (bsc#215290)
+#!BuildConflicts: libpxbackend-1_0-mini
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1222611

Port https://github.com/openSUSE/installation-images/pull/662 and https://github.com/openSUSE/installation-images/pull/659 to SLE15-SP6.

## Original problem

- https://bugzilla.suse.com/show_bug.cgi?id=1215290

Unwanted choice between ``libpxbackend-1_0` and `libpxbackend-1_0-mini` slips in which has to be avoided explicitly.

## Solution

This has to be adjusted in two places:

1. adjust `root.file_list` for local builds outside OBS
2. adjust spec file to avoid  `libpxbackend-1_0-mini`  in OBS
3. Bonus: drop `wget` - it is not used.