### PR TITLE
memtest86+ package change: memtest.bin is now in /usr/lib (bsc#1221221)

### DIFF
--- a/data/boot/boot.file_list
+++ b/data/boot/boot.file_list
@@ -15,7 +15,11 @@ if arch eq 'i386' || arch eq 'x86_64'
     endif
 
   memtest86+:
-    m /boot/memtest.bin /loader/memtest
+    if exists(memtest86+,/boot/memtest.bin)
+      m /boot/memtest.bin /loader/memtest
+    else
+      m /usr/lib/memtest86/memtest.bin /loader/memtest
+    endif
 
   if exists(syslinux6)
     syslinux6:

--- a/data/boot/grub-efi.cfg
+++ b/data/boot/grub-efi.cfg
@@ -94,6 +94,12 @@ submenu 'More ...' {
     initrd /boot/@arch@/initrd
   }
 
+<x86_64>
+  menuentry 'Memory Test' --class opensuse --class gnu-linux --class gnu {
+    set gfxpayload=keep
+    linux /EFI/BOOT/memtest.efi
+  }
+</x86_64>
 }
 
 # On EFI systems we can only have graphics *or* serial, so allow the user

--- a/data/boot/grub2-efi.file_list
+++ b/data/boot/grub2-efi.file_list
@@ -55,6 +55,11 @@ if exists(shim)
     a <shim_dir>/MokManager.efi EFI/BOOT/
 endif
 
+if arch eq 'x86_64' && exists(memtest86+,/usr/lib/memtest86/memtest.efi)
+  memtest86+:
+    m /usr/lib/memtest86/memtest.efi EFI/BOOT/
+endif
+
 # show product name in title instead of default grub string
 d EFI/BOOT/locale
 x grub2_head.po .


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1221221

`memtest86+` package has moved `memtest.bin` from `/boot` to `/usr/lib/memtest86`.

## Bonus

Create 'Memory Test' entry for `memtest.efi` on x86_64 UEFI systems.