### PR TITLE
Drop xiterm dependency

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -520,10 +520,6 @@ libgbm*:
 icewm-lite:
   /usr/bin/icewm-lite
 
-# don't include fonts - it prefers /usr/share/fonts/misc anyway
-fbiterm:
-  /usr/bin/fbiterm
-
 if exists(adobe-sourcesanspro-fonts,/usr/share/fonts/truetype/SourceSansPro-Regular.otf)
   adobe-sourcesanspro-fonts:
     /usr/share/fonts/truetype/SourceSansPro-{Regular,Light,Semibold}.otf
@@ -537,11 +533,6 @@ endif
 dejavu-fonts:
   /usr/share/fonts/truetype/DejaVuSans*.ttf
   r /usr/share/fonts/truetype/DejaVuSansCondensed*
-
-efont-unicode-bitmap-fonts:
-  # fonts used by fbiterm
-  /usr/share/fonts/misc/h16.pcf.gz
-  /usr/share/fonts/misc/b16.pcf.gz
 
 ?google-roboto-fonts:
 

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -341,7 +341,6 @@ BuildRequires:  google-noto-naskharabic-fonts
 %if %with_exfat
 BuildRequires:  exfatprogs
 %endif
-BuildRequires:  fbiterm
 BuildRequires:  fonts-config
 BuildRequires:  gamin-server
 BuildRequires:  gdb


### PR DESCRIPTION
fbiterm (xiterm) is a dead project - the latest change is from 2004. It does not appear to work well on recent kernels with several drivers. Factory has mlterm-sdl2 and SDL2 updated to not cache kernel keymap, both are projects actively maintained upstream. Now also fails to build with gcc 14
Related JIRA references: jsc#PED-3655 jsc#PED-7839