### PR TITLE
increase XZ compression level for initrd (bsc#1223982)

### DIFF
--- a/bin/mk_image
+++ b/bin/mk_image
@@ -55,6 +55,7 @@ $imagetype = $ENV{fs};
 $imagetype = "none" unless $imagetype;
 $use_compress = 'gzip' if $imagetype =~ s/\.gz$//;
 $use_compress = 'xz' if $imagetype =~ s/\.xz$//;
+$use_compress = 'zstd' if $imagetype =~ s/\.zst$//;
 
 # modes: keep, add, "" (default)
 @mode{split ",", $ENV{mode}} = ( 1 .. 10 );

--- a/lib/CompressImage.pm
+++ b/lib/CompressImage.pm
@@ -61,6 +61,7 @@ sub CompressImage
 
   $prog_opt = '-cf9N' if $prog eq 'gzip';
   $prog_opt = '--threads=0 -9 --check=crc32 -cf' if $prog eq 'xz';
+  $prog_opt = '--threads=0 -19 -cf' if $prog eq 'zstd';
 
   die "$Script: $prog failed" if system "$prog $prog_opt '$image2' >'$image2.tmp'";
 

--- a/lib/CompressImage.pm
+++ b/lib/CompressImage.pm
@@ -60,7 +60,7 @@ sub CompressImage
   print "compressing $image...\n";
 
   $prog_opt = '-cf9N' if $prog eq 'gzip';
-  $prog_opt = '--threads=0 --check=crc32 -cf' if $prog eq 'xz';
+  $prog_opt = '--threads=0 -9 --check=crc32 -cf' if $prog eq 'xz';
 
   die "$Script: $prog failed" if system "$prog $prog_opt '$image2' >'$image2.tmp'";
 


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1223982

Initrd size gets too big on ppc64. For a small size reduction, increase initrd compression level.

Using zstd instead of xz gets worse results.