### PR TITLE
Build Slowroll-specific tftpboot-installation rpm

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -91,6 +91,7 @@ ExclusiveArch:  do_not_build
 
 %if "%flavor" == "Slowroll"
 %define theme Slowroll
+%define product_name_suffix -Slowroll
 %define net_repo https://download.opensuse.org/slowroll/repo/oss
 %endif
 
@@ -152,7 +153,7 @@ ExclusiveArch:  do_not_build
 
 # ===  set product string (based on required packages)  ===
 
-%global product_name %(bash %_sourcedir/product_name)
+%global product_name %(bash %_sourcedir/product_name)%{?product_name_suffix}
 
 # ===  define each theme  ===
 


### PR DESCRIPTION
Without this change, it would also produce a `tftpboot-installation-openSUSE-Tumbleweed` rpm and conflict with the `:openSUSE` multibuild

We want to be able to boot a Slowroll NET iso off a snapshot of the Tumbleweed ftp-tree, so we need to be able to build it in openSUSE:Factory.