### PR TITLE
Use dedicated path for Slowroll tftpboot files

### DIFF
--- a/etc/config
+++ b/etc/config
@@ -102,6 +102,7 @@ gfxboot           = openSUSE
 grub2             = openSUSE
 plymouth          = openSUSE
 systemd           = openSUSE
+product_name      = openSUSE-Tumbleweed-Slowroll
 
 [Theme LeapMicro]
 image             = 350


### PR DESCRIPTION
Use dedicated path for `tftpboot-installation-openSUSE-Tumbleweed-Slowroll` files
so in can be installed in parallel to the Tumbleweed files