### PR TITLE
etc: update module.config to match 6.10

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -126,6 +126,7 @@ lis3lv02d,-,-
 bcm2835-dma
 bcma
 caif_hsi
+pfcp
 ptp
 ptp_clockmatrix
 ptp_dfl_tod


### PR DESCRIPTION
6.10 brought a new module in torvalds/linux@76c8764ef36a (pfcp: add PFCP
module): pfcp. Put this tunnelling proto into [other].

> Packet Forwarding Control Protocol (PFCP) is a 3GPP Protocol used between the control plane and the user plane function. It is specified in TS 29.244[1].