### PR TITLE
Add explicit dependency on 'attr'.

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -321,6 +321,7 @@ BuildRequires:  adaptec-firmware
 BuildRequires:  alsa
 BuildRequires:  alsa-utils
 BuildRequires:  arphic-uming-fonts
+BuildRequires:  attr
 BuildRequires:  audit-libs
 BuildRequires:  bc
 BuildRequires:  bcache-tools


### PR DESCRIPTION
We should not rely on OBS installing this unconditionally
