### PR TITLE
require libsolv-tools explicitly (bsc#1227672)

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -210,7 +210,7 @@ BuildRequires:  distribution-logos-openSUSE-LeapMicro
 BuildRequires:  SLE-Micro-release
 %endif
 # system-group-kvm needed for 15-SP2 based MicroOS
-BuildRequires:  system-group-kvm 
+BuildRequires:  system-group-kvm
 %endif
 
 %if "%theme" == "MicroOS"
@@ -406,6 +406,7 @@ BuildRequires:  kmod-compat
 BuildRequires:  krb5-devel
 BuildRequires:  less
 BuildRequires:  libpcsclite1
+BuildRequires:  libsolv-tools
 BuildRequires:  libyui-ncurses
 BuildRequires:  libyui-ncurses-pkg
 BuildRequires:  libyui-ncurses-rest-api
@@ -827,8 +828,8 @@ ln -s loader/initrd %{buildroot}/branding/%theme/CD1/boot/x86_64/initrd-xen
 ln -s loader/linux %{buildroot}/CD1/boot/x86_64/vmlinuz-xen
 %endif
 %endif
-# get rid of /usr/lib/rpm/brp-strip-debug 
-# strip kills the zImage.chrp-rs6k 
+# get rid of /usr/lib/rpm/brp-strip-debug
+# strip kills the zImage.chrp-rs6k
 export NO_BRP_STRIP_DEBUG=true
 export NO_DEBUGINFO_STRIP_DEBUG=true
 # for compatibility
@@ -871,7 +872,7 @@ install -D -m 644 images/cd1.iso %{_topdir}/ISO/cd1.iso
 %post -n install-initrd-%{theme}
 /bin/ln -snf %theme /usr/lib/install-initrd/branding 2>/dev/null || true
 
-%clean 
+%clean
 rm -rf %{buildroot}
 
 %files


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1227672

Port https://github.com/openSUSE/installation-images/pull/710 to SLE15-SP7.

`libsolv-tools` is now explicitly required. Previously it was implicitly installed via `libsolv`.