### PR TITLE
make some compression settings configurable (bsc#1223982, jsc#PED-8374)

### DIFF
--- a/doc/compression.md
+++ b/doc/compression.md
@@ -1,0 +1,13 @@
+# Adjusting compression
+
+The environment variable `instsys_no_compression` accepts a comma-separated
+list of values to omit compression in certain places.
+
+It is usually not a good idea to change the default settings but it might
+help in some specific cases - notably on ppc64 (see bsc#1223982 and jsc#PED-8374).
+
+Accepted values are:
+
+- squashfs: Do not compress squashfs images in initrd.
+- modules: Do not compress kernel modules. Uncompress them if they are found compressed in kernel packages.
+- firmware: Do not compress kernel firmware. Uncompress them if they are found compressed in kernel packages.

--- a/gefrickel
+++ b/gefrickel
@@ -10,8 +10,13 @@ function err {
 }
 
 function squash {
+  local compression="-comp xz"
+  # see doc/compression.md
+  if [[ "$instsys_no_compression" =~ "squashfs" ]] ; then
+    compression="-no-compression"
+  fi
   mkdir -p parts
-  $mksquashfs $1 parts/$2 -comp xz -noappend -no-progress
+  $mksquashfs $1 parts/$2 $compression -noappend -no-progress
   chmod 644 parts/$2
 }
 
@@ -29,6 +34,11 @@ cd $dir
 
 if [ -L lib ]; then
   pfx="usr/"
+fi
+
+if [ -n "$instsys_no_compression" ] ; then
+  echo "$instsys_no_compression" > .no_compression
+  echo "using no compression in squashfs\n"
 fi
 
 # - - -  lib/{modules,firmware}  - - -

--- a/lib/CompressImage.pm
+++ b/lib/CompressImage.pm
@@ -60,8 +60,12 @@ sub CompressImage
   print "compressing $image...\n";
 
   $prog_opt = '-cf9N' if $prog eq 'gzip';
-  $prog_opt = '--threads=0 -9 --check=crc32 -cf' if $prog eq 'xz';
-  $prog_opt = '--threads=0 -19 -cf' if $prog eq 'zstd';
+
+  # build system provides at least 4 cpus
+  my $threads = $ConfigData{in_abuild} ? 4 : 0;
+
+  $prog_opt = "--threads=$threads -9 --check=crc32 -cf" if $prog eq 'xz';
+  $prog_opt = "--threads=$threads -19 -cf" if $prog eq 'zstd';
 
   die "$Script: $prog failed" if system "$prog $prog_opt '$image2' >'$image2.tmp'";
 

--- a/lib/CompressImage.pm
+++ b/lib/CompressImage.pm
@@ -38,6 +38,8 @@ require Exporter;
 use strict 'vars';
 use integer;
 
+use vars qw (%ConfigData);
+
 sub CompressImage
 {
   local $_;

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -522,6 +522,41 @@ sub ReadRPM
       print "warning: kmp/firmware version mismatch: $_\n";
       SUSystem "sh -c 'tar -C $tdir/lib/modules/$_ -cf - . | tar -C $tdir/lib/modules/$kv -xf -'";
     }
+
+    # unpack kernel modules if requested
+    # see doc/compression.md
+    if($ENV{instsys_no_compression} =~ /modules/) {
+      my $dir = "$tdir/usr/lib/modules";
+      $dir = "$tdir/lib/modules" if ! -d $dir;
+
+      print "uncompressing kernel modules...\n";
+
+      SUSystem "find $dir -type f -name \*.ko.zst -exec zstd -d --quiet --rm '{}' \\;";
+      SUSystem "find $dir -type f -name \*.ko.xz -exec xz -d '{}' \\;";
+      SUSystem "find $dir -type f -name \*.ko.gz -exec gzip -d '{}' \\;";
+    }
+
+    # unpack kernel firmware if requested
+    # see doc/compression.md
+    if($ENV{instsys_no_compression} =~ /firmware/) {
+      my $dir = "$tdir/usr/lib/firmware";
+      $dir = "$tdir/lib/firmware" if ! -d $dir;
+
+      print "uncompressing kernel firmware...\n";
+
+      # rename symlinks
+      for my $suffix ("zst", "xz", "gz") {
+        SUSystem "find $dir -type l -name \*.$suffix -exec rename -sl .$suffix '' '{}' \\; -exec rename -l .$suffix '' '{}' \\;";
+      }
+
+      # unpack files
+      SUSystem "find $dir -type f -name \*.zst -exec zstd -d --quiet --rm '{}' \\;";
+      SUSystem "find $dir -type f -name \*.xz -exec xz -d '{}' \\;";
+      SUSystem "find $dir -type f -name \*.gz -exec gzip -d '{}' \\;";
+
+      my $broken = `find $dir -follow -type l`;
+      die "firmware uncompressing left broken symlinks:\n$broken\n" if $broken ne "";
+    }
   }
 
   return $err ? undef : $dir;

--- a/lib/ReadConfig.pm
+++ b/lib/ReadConfig.pm
@@ -1282,6 +1282,8 @@ $ConfigData{fw_list} = $ConfigData{ini}{Firmware}{$arch} if $ConfigData{ini}{Fir
   $in_abuild = $ConfigData{buildenv}{BUILD_BASENAME} ? 1 : 0;
   $in_abuild = 1 if -d "$ConfigData{buildroot}/.build.binaries";
 
+  $ConfigData{in_abuild} = $in_abuild;
+
   # print STDERR "abuild = $in_abuild\n";
 
   die "\nError: *** you must be root to build images ***\n\n" if $>;

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -775,6 +775,10 @@ export BUILD_DISTRIBUTION_NAME
 test ! -z "$BUILD_DISTRIBUTION_NAME"
 # build id (for linuxrc to start the correct instsys)
 export instsys_build_id=`bin/build_id`
+%ifarch ppc64 ppc64le
+# ppc64: optimize for smaller compressed initrd size
+export instsys_no_compression=squashfs
+%endif
 # beta only: warn testers about wrong instsys
 export instsys_complain=1
 # careful: will make all non-matching initrds fail hard


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/726 to SLE15-SP6.

The difference here is that only the squashfs compression is disabled.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1223982
- https://jira.suse.com/browse/PED-8374

Introduce environment variable `instsys_no_compression` to allow influencing compression strategy in some places. Notably for ppc64.

## Bonus

Limit compression threads in OBS to 4 threads, for reproducible builds.