### PR TITLE
Revert "drop unused wget (bsc#1215290)" (bsc#1228736)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -202,6 +202,7 @@ tar:
 terminfo-base:
 usbutils:
 vlan:
+wget:
 ?wicked:
 ?xen-tools-domU:
 xfsdump:

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -203,6 +203,7 @@ systemd:
 udftools:
 usbutils:
 util-linux:
+wget:
 xfsdump:
 xfsprogs:
 xz:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -517,6 +517,7 @@ BuildRequires:  valgrind
 BuildRequires:  vim-small
 # libproxy1 requires libpxbackend-1_0; to counter cycles, this exists also as mini (bsc#215290)
 #!BuildConflicts: libpxbackend-1_0-mini
+BuildRequires:  wget
 BuildRequires:  wicked
 BuildRequires:  wicked-nbft
 BuildRequires:  wireless-tools


### PR DESCRIPTION
## Task

Port https://github.com/openSUSE/installation-images/pull/731 to SLE15-SP7.

## Original task

- https://bugzilla.suse.com/show_bug.cgi?id=1228736

Revert https://github.com/openSUSE/installation-images/pull/659 as it turns out `wget` is actually used by customers in their AutoYaST profiles.