### PR TITLE
bring back b16.pcf (bsc#1228691)

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -535,6 +535,10 @@ dejavu-fonts:
   /usr/share/fonts/truetype/DejaVuSans*.ttf
   r /usr/share/fonts/truetype/DejaVuSansCondensed*
 
+# needed by yast as fallback for CJK languages
+efont-unicode-bitmap-fonts:
+  /usr/share/fonts/misc/b16.pcf.gz
+
 ?google-roboto-fonts:
 
 ?noto-sans-fonts:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -355,6 +355,7 @@ BuildRequires:  dosfstools
 BuildRequires:  dump
 BuildRequires:  e2fsprogs
 BuildRequires:  ed
+BuildRequires:  efont-unicode-bitmap-fonts
 BuildRequires:  elfutils
 BuildRequires:  ethtool
 BuildRequires:  google-noto-naskharabic-fonts


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1228691

The `b16.pcf` font had been removed along with fbiterm (bsc#1224053) but it turned out YaST has redering problems with CJK languages and having a bitmap font as fallback is quite useful.