### PR TITLE
Add kernel modules for Qualcomm RB3Gen2 (bsc#1231167)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -201,6 +201,9 @@ smp2p
 spmi-pmic-arb
 spmi-mtk-pmif
 
+qnoc-sc7280
+ufs-qcom
+
 reset-raspberrypi
 clk-raspberrypi
 raspberrypi-cpufreq

--- a/etc/module.list
+++ b/etc/module.list
@@ -289,6 +289,10 @@ kernel/drivers/soc/qcom/smp2p.ko
 kernel/drivers/spmi/spmi-pmic-arb.ko
 kernel/drivers/spmi/spmi-mtk-pmif.ko
 
+# Qcom rb3gen2
+kernel/drivers/interconnect/qcom/qnoc-sc7280.ko
+kernel/drivers/ufs/host/ufs-qcom.ko
+
 kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
 kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko


### PR DESCRIPTION
Bugzilla: https://bugzilla.opensuse.org/show_bug.cgi?id=1231167

Add kernel missing kernel modules for UFS support.

Other basic and clock modules are already available as part of the changes done for Lenovo X13s support.