### PR TITLE
Remove obsolete ignores

### DIFF
--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -206,16 +206,8 @@ p11-kit:
 ?sle12-desktop-migration:
 
 novnc:
-python38-setuptools: ignore
-python310-setuptools: ignore
 
 add_all skelcd-fallbackrepo-.*:
-
-# normally python3X-websockify would require python3X-numpy but the
-# dependency is actually optional in the code - so avoid it to
-# save **a lot** of space
-python38-numpy: ignore
-python310-numpy: ignore
 
 vim-small:
 


### PR DESCRIPTION
python38 and python310 hasn't been used in ages for any maintained distribution.