### PR TITLE
Remove dependency on xf86-video-fbdev (boo#1212947).

### DIFF
--- a/data/root/etc/xorg.conf.template
+++ b/data/root/etc/xorg.conf.template
@@ -11,16 +11,6 @@ Section "Screen"
 EndSection
 
 Section "Device"
-  Identifier "fbdev"
-  Driver  "fbdev"
-EndSection
-
-Section "Screen"
-  Identifier "fbdev"
-  Device "fbdev"
-EndSection
-
-Section "Device"
   Identifier "vesa"
   Driver  "vesa"
 EndSection
@@ -33,6 +23,5 @@ EndSection
 Section "ServerLayout"
   Identifier "Layout"
   Screen  "modesetting"
-  Screen  "fbdev"
   Screen  "vesa"
 EndSection

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -440,7 +440,6 @@ if exists(xorg-x11-server,/usr/bin/Xorg)
   ?xf86-input-evdev:
   ?xf86-input-libinput:
   ?xf86-input-wacom:
-  ?xf86-video-fbdev:
   ?xf86-video-vesa:
 
   ?virtualbox-guest-x11: nodeps

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -589,7 +589,6 @@ BuildRequires:  xf86-video-qxl
 BuildRequires:  xf86-video-vesa
 %endif
 BuildRequires:  xf86-input-wacom
-BuildRequires:  xf86-video-fbdev
 %endif
 BuildRequires:  grub2
 %ifarch ppc ppc64 ppc64le


### PR DESCRIPTION
The kernel interface that xf86-video-fbdev uses is about to be disabled in the Factory kernel.

With that there is no point carrying the driver. The modesetting driver should work with all supported platforms.