### PR TITLE
Drop dbus-1-x11 build dependency

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -345,7 +345,6 @@ BuildRequires:  cups-libs
 BuildRequires:  curl
 BuildRequires:  dash
 BuildRequires:  dbus-1-daemon
-BuildRequires:  dbus-1-x11
 BuildRequires:  dd_rescue
 BuildRequires:  debuginfod-client
 BuildRequires:  dejavu-fonts


### PR DESCRIPTION
Since #149 dbus-1-x11 is already ignored in all images, and thus unused.
With Tumbleweed having switched to dbus-broker, the -x11 flavored dbus-launch
will be removed.
