### PR TITLE
add extra sync before removing zram swap device (bsc#1233893)

### DIFF
--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -209,6 +209,8 @@ create_zram_swap_disable_hook() {
 # at least 2 swap devices
 if [ "\$(wc -l < /proc/swaps)" != 2 ] ; then
   swapoff $zram_swap_dev
+  sync
+  sleep 1
   echo $zram_dev_index > /sys/class/zram-control/hot_remove
 fi
 XXX


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1233893

Removing the zram swap device immediately after a `swapoff` command fails. Possibly a race condition.

Adding a `sync` and `sleep` giving the kernel some time to sort things out helps to avoid it.
