### PR TITLE
etc: update module.config to match 6.13

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -138,6 +138,7 @@ ptp_mock
 ptp_ocp
 ptp_pch
 ptp_qoriq
+ptp_vmclock
 ptp_vmw
 ptp-qoriq
 pps_core


### PR DESCRIPTION
6.13 brought a new module in torvalds/linux@205032724226 (ptp: Add support for the AMZNC10C 'vmclock' device): ptp_vmclock. Put this tunnelling proto into [other].

> This driver adds support for using a virtual precision clock
> advertised by the hypervisor. This clock is only useful in virtual
> machines where such a device is present.