### PR TITLE
fix zram setup taking new module dependencies into account (bsc#1235440)

### DIFF
--- a/data/initrd/scripts/zram_setup
+++ b/data/initrd/scripts/zram_setup
@@ -6,7 +6,7 @@ size=$1
 PATH=/usr/bin:/usr/sbin:/bin:/sbin
 
 # no modprobe
-for i in zram jbd2 mbcache crc16 ext4 ; do
+for i in 842_decompress 842_compress lz4_compress lz4hc_compress zram jbd2 mbcache crc16 ext4 ; do
   for ext in .ko .ko.xz .ko.zst ; do
     m=/modules/$i$ext
     [ -f $m ] && insmod $m

--- a/gefrickel
+++ b/gefrickel
@@ -45,7 +45,9 @@ fi
 #
 # all mods ex loop & squashfs
 #
-base_modules="loop squashfs lz4_decompress xxhash zstd_decompress zram ext4 crc16 mbcache jbd2"
+# see also data/initrd/scripts/zram_setup
+#
+base_modules="loop squashfs lz4_decompress lz4_compress lz4hc_compress 842_compress 842_decompress xxhash zstd_decompress zram ext4 crc16 mbcache jbd2"
 echo "$base_modules" > .base_modules
 m_dir=`echo ${pfx}lib/modules/*/initrd`
 [ -d "$m_dir" ] || err "no kernel module dir"


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1235440

Latest kernels add several compression module dependencies to `zram.ko`.

The modules have to be made available and must be loaded explicitly since at this stage of the installation system setup config files with module dependencies are not yet available.