### PR TITLE
rpm2cpio is symlink to rpm2archive in rpm 4.20 (bsc#1235897)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -300,6 +300,7 @@ sysvinit-tools: nodeps
 
 rpm:
   /usr/bin/rpm2cpio
+  /usr/bin/rpm2archive
   /usr/bin/rpmkeys
   /usr/lib*/librpm{,io}.so.*
   /usr/lib/rpm/rpmrc


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1235897

Latest `rpm` package (4.20) makes `rpm2cpio` symlink to `rpm2archive`.