### PR TITLE
remove obsolete nscd (bsc#1236238)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -333,10 +333,6 @@ gawk:
   /usr/bin/gawk
   s gawk usr/bin/awk
 
-nscd:
-  # remaining files are in root image
-  d /var/run/nscd
-
 ?virtualbox-guest-tools: nodeps
   /usr/lib/udev/rules.d
 
@@ -497,10 +493,6 @@ udev:
 
 # we just want the user & group entries
 polkit: nodeps
-  E prein
-
-# we just want the user & group entries
-nscd:
   E prein
 
 # we just want the user & group entries

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -170,7 +170,6 @@ mingetty:
 ncurses-utils:
 netcat-openbsd:
 netcfg:
-nscd:
 ntfsprogs:
 nvme-cli:
 open-iscsi:

--- a/data/root/etc/inst_setup
+++ b/data/root/etc/inst_setup
@@ -107,18 +107,6 @@ if [ -x /sbin/klogd ] ; then
   }
 fi
 
-# start nscd (bnc #530440, bnc #878904)
-if [ -x /usr/sbin/nscd ] ; then
-  checkproc /usr/sbin/nscd || {
-    echo -n "starting nscd..."
-    if /usr/sbin/nscd ; then
-      echo " ok"
-    else
-      echo " failed"
-    fi
-  }
-fi
-
 # Update module config.
 #
 # Note: modules are all from initrd, but new ones might have come in via
@@ -285,8 +273,6 @@ fi
 
 # start shell, useful on iSeries or via serial console
 [ "$START_SHELL" ] && start_shell
-
-nscd --shutdown
 
 # stop various daemons
 # killall dbus-daemon >/dev/null 2>&1

--- a/data/root/root.file_list
+++ b/data/root/root.file_list
@@ -368,12 +368,6 @@ cracklib: nodeps
   x etc/ssh /lib
   x ../rescue/mount-rootfs-and-do-chroot /bin
 
-nscd:
-  /etc
-  /usr
-  # turn off passwd & group caching
-  R s/(enable-cache\s+(passwd|group)\s+)yes/$1no/g /etc/nscd.conf
-
 shadow:
   if exists(shadow, /usr/lib/pam.d)
     /usr/lib/pam.d

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -477,7 +477,6 @@ BuildRequires:  plymouth-theme-tribar
 %endif
 BuildRequires:  klogd
 BuildRequires:  ltrace
-BuildRequires:  nscd
 BuildRequires:  polkit
 BuildRequires:  popt-devel
 BuildRequires:  pothana2000


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1236238

`nscd` is obsolete and should not be used.