### PR TITLE
system-user-nobody needed by latest rpcbind package (bsc#1236617)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -450,6 +450,7 @@ e2fsprogs:
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 system-user-daemon:
+system-user-nobody:
 system-user-tss:
 system-group-kvm:
 


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1236617

Add system-user-nobody package to initrd; required by latest rpcbind package.