### PR TITLE
remove obsolete setserial package (bsc#1239516)

### DIFF
--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -183,7 +183,6 @@ procps:
 psmisc:
 sdparm:
 sed:
-setserial:
 sg3_utils:
 smartmontools:
 smp_utils:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -489,7 +489,6 @@ BuildRequires:  rsync
 BuildRequires:  rsyslog
 BuildRequires:  screen
 BuildRequires:  sdparm
-BuildRequires:  setserial
 BuildRequires:  setxkbmap
 BuildRequires:  sg3_utils
 BuildRequires:  sharutils


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1239516

Remove obsolete `setserial` package.