### PR TITLE
adjust s390x module config (bsc#1239659)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -138,6 +138,7 @@ ptp_mock
 ptp_ocp
 ptp_pch
 ptp_qoriq
+ptp_s390
 ptp_vmclock
 ptp_vmw
 ptp-qoriq


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1239659

A new kernel module `ptp_s390` appeared.