### PR TITLE
pcre is not longer required

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -441,7 +441,6 @@ BuildRequires:  pango
 BuildRequires:  pango-tools
 BuildRequires:  parted
 BuildRequires:  pciutils
-BuildRequires:  pcre-devel
 BuildRequires:  pcsc-lite
 BuildRequires:  perl-Config-Crontab
 BuildRequires:  perl-HTML-Parser


### PR DESCRIPTION
pcre is not longer required by any package to build the images

You can find some context at https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/BK3SPPFOM3LI6K5PTXPKZMKMIUIPOEXS/#T6K3AN5Q6MYTCXZVWBRCWSRP6LFPLBNK