### PR TITLE
etc: update module.config to match 6.15

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -695,9 +695,10 @@ ifb
 ioc3
 ipwireless
 iscsi_trgt
-mctp-serial
 mctp-i2c
 mctp-i3c
+mctp-serial
+mctp-usb
 msdos
 netdevsim
 parport_ax88796


### PR DESCRIPTION
6.15 brought a new module mctp-usb, add it along other mctp modules.

(And order mctp alphabetically.)