### PR TITLE
etc: add mtu3 and onboard_usb_dev to module.config (bsc#1244269)

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -219,6 +219,8 @@ mdio-bcm-unimac
 mt6360_charger
 mtk-pmic-wrap
 nvmem_mtk-efuse
+mtu3
+onboard_usb_dev
 uio_hv_generic
 
 kernel/arch/.*/crypto/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -302,6 +302,8 @@ kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
 kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko
 kernel/drivers/clk/
+kernel/drivers/usb/mtu3/
+kernel/drivers/misc/onboard_usb_dev.ko
 
 kernel/drivers/spi/
 kernel/drivers/dma/pl330.ko


### PR DESCRIPTION
mtu3 and onboard_usb_dev module was added to stable/Tumbleweed. Enumerate it in [other].