### PR TITLE
etc: add imx8mp interconnect to module.config

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -223,6 +223,9 @@ mtu3
 onboard_usb_dev
 uio_hv_generic
 
+imx-interconnect
+imx8mp-interconnect
+
 kernel/arch/.*/crypto/.*
 kernel/arch/.*/kernel/.*,,-
 kernel/crypto/.*

--- a/etc/module.list
+++ b/etc/module.list
@@ -266,6 +266,10 @@ kernel/drivers/dma/tegra20-apb-dma.ko
 
 kernel/drivers/virt/vboxguest/
 
+#NXP i.MX8MP
+kernel/drivers/interconnect/imx/imx-interconnect.ko
+kernel/drivers/interconnect/imx/imx8mp-interconnect.ko
+
 # RPi4
 kernel/drivers/reset/reset-raspberrypi.ko
 kernel/drivers/clk/bcm/clk-raspberrypi.ko


### PR DESCRIPTION
Add i.MX8MP interconnect modules to make USB disk could be used when installing from USB.

I am not able to test this changes, because I not have enviorment to build the installer. Just follow the discussion [1] to make this PR.

[1] https://bugzilla.suse.com/show_bug.cgi?id=1246854