### PR TITLE
add libopenssl-3-fips-provider to make fips work (bsc#1244208)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -89,6 +89,7 @@ kpartx:
 kmod:
 ?kmod-compat:
 krb5:
+?libopenssl-3-fips-provider:
 lsscsi:
 mdadm:
 netcfg:

--- a/data/rescue/rescue.file_list
+++ b/data/rescue/rescue.file_list
@@ -168,6 +168,7 @@ kmod:
 ?kmod-compat:
 kpartx:
 krb5:
+?libopenssl-3-fips-provider:
 lsscsi:
 mingetty:
 ncurses-utils:

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -404,6 +404,7 @@ BuildRequires:  khmeros-fonts
 BuildRequires:  kmod-compat
 BuildRequires:  krb5-devel
 BuildRequires:  less
+BuildRequires:  libopenssl-3-fips-provider
 BuildRequires:  libpcsclite1
 BuildRequires:  libsolv-tools
 BuildRequires:  libyui-ncurses


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1244208

Add `libopenssl-3-fips-provider` package to make `fips=1` boot option work.