### PR TITLE
initrd: add /usr/bin/chage to allow users with expiry date being created

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -349,6 +349,7 @@ shadow:
   else
     /usr/etc/pam.d
   endif
+  /usr/bin/chage
   /usr/sbin/groupadd
   /usr/sbin/useradd
   /usr/sbin/useradd.local


### PR DESCRIPTION
https://bugzilla.opensuse.org/show_bug.cgi?id=1248731