### PR TITLE
etc: add qnoc-sa8775p kernel module for Qualcomm RB8 device

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -205,6 +205,7 @@ spmi-pmic-arb
 spmi-mtk-pmif
 
 qnoc-sc7280
+qnoc-sa8775p
 ufs-qcom
 
 reset-raspberrypi

--- a/etc/module.list
+++ b/etc/module.list
@@ -302,6 +302,9 @@ kernel/drivers/spmi/spmi-mtk-pmif.ko
 kernel/drivers/interconnect/qcom/qnoc-sc7280.ko
 kernel/drivers/ufs/host/ufs-qcom.ko
 
+# Qcom rb8
+kernel/drivers/interconnect/qcom/qnoc-sa8775p.ko
+
 kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
 kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko


### PR DESCRIPTION
Add missing module qnoc-sa8775p to validate openSUSE Tumbleweed on QCOM-based arm64 platform ( RB8 device ), other required modules are already available.