### PR TITLE
etc: fix path for onboard_usb_dev in module.list (bsc#1244269)

### DIFF
--- a/etc/module.list
+++ b/etc/module.list
@@ -307,7 +307,7 @@ kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko
 kernel/drivers/clk/
 kernel/drivers/usb/mtu3/
-kernel/drivers/misc/onboard_usb_dev.ko
+kernel/drivers/usb/misc/onboard_usb_dev.ko
 
 kernel/drivers/spi/
 kernel/drivers/dma/pl330.ko


### PR DESCRIPTION
The 'usb' string seems missing in the path for onboard_usb_dev.ko. 
Update the entry with "kernel/drivers/usb/misc/onboard_usb_dev.ko".