### PR TITLE
Packaging: fix disabling mtime clamping

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -25,7 +25,8 @@
 # Since they are all auto-generated files, so they keep on changing. Having the mtime
 # constant though causes issues for rsync - which uses this information by default to decide
 # wether there is something to sync or not
-%global clamp_mtime_to_source_date_epoch 0
+%global build_mtime_policy clamp_to_buildtime
+%global use_source_date_epoch_as_buildtime N
 
 # do not build 32-bit s390
 ExcludeArch:    s390


### PR DESCRIPTION
The skelcd package is being extracted onto the FTP Servers and then
rsynced to the mirrors. rsync uses size/date information to identify
if a package needs to be synced. As RPM,for reproducible builds, sets
the mtime of the files to the date/time of the last changelog entry,
we break rsync on extracted files

This used not to be a problem, as OBS, when it extracted files out
of the VM, was not preserving mtimes. This had a negative effect on
republishing larger, yet stable trees like Leap 16.0. With this
fixed, it became apparent that the pre-existing attempt to disable
mtime clamping in the package no longer works
