### PR TITLE
Build: use full ffmpeg package version

### DIFF
--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -553,6 +553,7 @@ BuildRequires:  sbl
 %endif
 %if %{with vnc}
 BuildRequires:  xorg-x11-Xvnc
+#!BuildConflicts: ffmpeg-8-mini-libs
 %endif
 # kmps
 %ifarch %ix86 x86_64


### PR DESCRIPTION
tigervnc newly provides wayland capabilities, which pulls in pipewire
and thus ffmpeg. Inside OBS, builds generally prefer the mini flavor
As installation-images tgough rebundles packages and leaves to consumers
it is not supposed to do this with the mini flavor
