### PR TITLE
MicroOS needs adapted minimalist zypp config (bsc#1256694)

### DIFF
--- a/data/initrd/initrd.file_list
+++ b/data/initrd/initrd.file_list
@@ -138,6 +138,11 @@ libzypp: nodeps
   /etc
   /usr/etc
   /var
+if patch_zypp_config_theme
+  zypp-no-recommends:
+  zypp-excludedocs:
+  zypp-no-multiversion:
+endif
 
 if exists(samba-client-libs)
   samba-client-libs: nodeps

--- a/obs/installation-images.spec
+++ b/obs/installation-images.spec
@@ -307,6 +307,9 @@ BuildRequires:  grub2-branding-%branding_grub2
 ExcludeArch:    %ix86
 %endif
 
+BuildRequires:  zypp-excludedocs
+BuildRequires:  zypp-no-multiversion
+BuildRequires:  zypp-no-recommends
 BuildRequires:  xf86-input-libinput
 BuildRequires:  google-roboto-fonts
 BuildRequires:  noto-sans-fonts


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1256694

For MicroOS, install
- zypp-excludedocs
- zypp-no-multiversion
- zypp-no-recommends

to get a minimalist installation. Putting `minimalistic_libzypp_config` into your product config xml does not work.