### PR TITLE
memtest86+: work also with Legacy BIOS (bsc#1264242)

### DIFF
--- a/data/boot/boot.file_list
+++ b/data/boot/boot.file_list
@@ -19,6 +19,8 @@ if arch eq 'i386' || arch eq 'x86_64'
       m /boot/memtest.bin /loader/memtest
     elsif exists(memtest86+,/usr/lib/memtest86/memtest.bin)
       m /usr/lib/memtest86/memtest.bin /loader/memtest
+    elsif exists(memtest86+,/usr/lib/memtest86/mt86plus.efi)
+      m /usr/lib/memtest86/mt86plus.efi /loader/memtest
     else
       R s/\n# memory test.*?\n\n/\n/s loader/isolinux.cfg
     endif


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1264242

Turns out the EFI binary (`mt86plus.efi`) is intended to work also with Legacy BIOS.