### PR TITLE
etc: add qnoc-qcs615 kernel module for Qualcomm QCS615/Talos Platform

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -207,6 +207,7 @@ spmi-mtk-pmif
 
 qnoc-sc7280
 qnoc-sa8775p
+qnoc-qcs615
 qnoc-qcs8300
 ufs-qcom
 

--- a/etc/module.list
+++ b/etc/module.list
@@ -305,6 +305,9 @@ kernel/drivers/ufs/host/ufs-qcom.ko
 # Qcom rb8
 kernel/drivers/interconnect/qcom/qnoc-sa8775p.ko
 
+# Qcom qcs615
+kernel/drivers/interconnect/qcom/qnoc-qcs615.ko
+
 # Qcom rb4
 kernel/drivers/interconnect/qcom/qnoc-qcs8300.ko
 


### PR DESCRIPTION
Add the qnoc-qcs615 interconnect kernel module for the Qualcomm QCS615/Talos platform to support SystemReady compliance. This allows generic Linux distribution ISO images to boot on QCS615-based hardware.