### PR TITLE
etc: add qnoc-x1e80100 kernel module for Qualcomm X1E80100 Platform

### DIFF
--- a/etc/module.config
+++ b/etc/module.config
@@ -208,6 +208,7 @@ spmi-mtk-pmif
 qnoc-sc7280
 qnoc-sa8775p
 qnoc-qcs8300
+qnoc-x1e80100
 ufs-qcom
 
 reset-raspberrypi

--- a/etc/module.list
+++ b/etc/module.list
@@ -308,6 +308,9 @@ kernel/drivers/interconnect/qcom/qnoc-sa8775p.ko
 # Qcom rb4
 kernel/drivers/interconnect/qcom/qnoc-qcs8300.ko
 
+# Qcom x1e80100
+kernel/drivers/interconnect/qcom/qnoc-x1e80100.ko
+
 kernel/drivers/soc/mediatek/mtk-pmic-wrap.ko
 kernel/drivers/power/supply/mt6360_charger.ko
 kernel/drivers/nvmem/nvmem_mtk-efuse.ko


### PR DESCRIPTION
Add the qnoc-x1e80100 interconnect kernel module for the Qualcomm X1E80100 platform to support SystemReady compliance. This allows generic Linux distribution ISO images to boot on X1E80100-based hardware.